### PR TITLE
chore(deps): oxc を 0.132 に bump して lock グラフを統一

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,10 +81,10 @@ name = "gates"
 version = "0.10.1"
 dependencies = [
  "litmus",
- "oxc_allocator 0.126.0",
- "oxc_ast 0.126.0",
- "oxc_parser 0.126.0",
- "oxc_span 0.126.0",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
  "regex",
  "serde",
  "serde_json",
@@ -98,18 +98,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
 ]
@@ -123,13 +114,13 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "litmus"
 version = "0.2.0"
-source = "git+https://github.com/thkt/litmus.git#c564e7a5c2d968d1c9d414d51a5e38602a468f05"
+source = "git+https://github.com/thkt/litmus.git#97222dbfea7c076b82a6367a478b7ba8d2110910"
 dependencies = [
  "glob",
- "oxc_allocator 0.121.0",
- "oxc_ast 0.121.0",
- "oxc_parser 0.121.0",
- "oxc_span 0.121.0",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
 ]
 
 [[package]]
@@ -206,80 +197,39 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17ece0d1edc5e92822be95428460bc6b12f0dce8f95a9efabf751189a75f9f2"
+checksum = "1b44db8e77f8ead7332d0dd95850d27fb7bb09f288761447e804be05ad2f89d3"
 dependencies = [
  "allocator-api2",
- "hashbrown 0.16.1",
- "oxc_data_structures 0.121.0",
- "rustc-hash",
-]
-
-[[package]]
-name = "oxc_allocator"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54dd7c5eb0fa364f0b7ca09109f21cede0ae5f72001163170d954d62a0e4e86"
-dependencies = [
- "allocator-api2",
- "hashbrown 0.17.0",
- "oxc_data_structures 0.126.0",
+ "hashbrown",
+ "oxc_data_structures",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_ast"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ec0e9560cce8917197c7b13be7288707177f48a6f0ca116d0b53689e18bbc3"
+checksum = "38b7d05623c5fb0a8e65ee6c1971811a6f5e2332711b14abbffd2d90fdb81786"
 dependencies = [
  "bitflags",
- "oxc_allocator 0.121.0",
- "oxc_ast_macros 0.121.0",
- "oxc_data_structures 0.121.0",
- "oxc_diagnostics 0.121.0",
- "oxc_estree 0.121.0",
- "oxc_regular_expression 0.121.0",
- "oxc_span 0.121.0",
- "oxc_syntax 0.121.0",
-]
-
-[[package]]
-name = "oxc_ast"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7391676b3f06b7cb8e720ec06daf052395bb7516a8b647992ce5a21ea997989"
-dependencies = [
- "bitflags",
- "oxc_allocator 0.126.0",
- "oxc_ast_macros 0.126.0",
- "oxc_data_structures 0.126.0",
- "oxc_diagnostics 0.126.0",
- "oxc_estree 0.126.0",
- "oxc_regular_expression 0.126.0",
- "oxc_span 0.126.0",
- "oxc_str 0.126.0",
- "oxc_syntax 0.126.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_estree",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f266c05258e76cb84d7eee538e4fc75e2687f4220e1b2f141c490b35025a6443"
-dependencies = [
- "phf",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "oxc_ast_macros"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6b396cf8aefca1f06445b28e434b16529b199bbb8a6157c905d7b5e4dfae90"
+checksum = "f585aec92e2bdd985857d9bf58ce6896b65ad4410cc24a9533a16b864b5de8d7"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -289,32 +239,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8701946f2acbd655610a331cf56f0aa58349ef792e6bf2fb65c56785b87fe8e"
-
-[[package]]
-name = "oxc_data_structures"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdea5ebbfe376448e83f9749828f31a0ad9b85a1b01e31f70597565b74f809a"
+checksum = "75a67baa093fb2410302bb5bea3be60c6f4e9d9573fda9d8561691234cd6bfde"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04ea16e6016eceb281fb61bbac5f860f075864e93ae15ec18b6c2d0b152e435"
-dependencies = [
- "cow-utils",
- "oxc-miette",
- "percent-encoding",
-]
-
-[[package]]
-name = "oxc_diagnostics"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ac2365c7cf9255776ceb41310c90d9e636586cf291ae9c0df50028f559837b"
+checksum = "cd40c6b1e961ee7e9e00ba2c924b11259ad23aa306c349a48539344f266ef5c5"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -323,47 +256,25 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b107cae9b8bce541a45463623e1c4b1bb073e81d966483720f0e831facdcb1"
+checksum = "32dfc8b140169c70350e98cbfee928be46ae60151c3af6e477521afae8288809"
 dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.121.0",
- "oxc_ast 0.121.0",
- "oxc_regular_expression 0.121.0",
- "oxc_span 0.121.0",
- "oxc_syntax 0.121.0",
-]
-
-[[package]]
-name = "oxc_ecmascript"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651a4509f2de47c7e49fc3a78e136e821062c4d97d2544c6336dda0f4513cfc6"
-dependencies = [
- "cow-utils",
- "num-bigint",
- "num-traits",
- "oxc_allocator 0.126.0",
- "oxc_ast 0.126.0",
- "oxc_regular_expression 0.126.0",
- "oxc_span 0.126.0",
- "oxc_syntax 0.126.0",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_estree"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b79c9e9684eab83293d67dcbbfd2b1a1f062d27a8188411eb700c6e17983fa"
-
-[[package]]
-name = "oxc_estree"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891d31bbe5e6c3a849a2db7de16015076f0d83f42110ace1fdfd7d2e886b97c"
+checksum = "d13f41b137ab39f80c5ab3277e777302bfd8e9b937b760159bb0996e0b2467aa"
 
 [[package]]
 name = "oxc_index"
@@ -377,79 +288,40 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f41bdacb3ef9afd8c5b0cb5beceec3ac4ecd0c348804aa1907606d370c731"
+checksum = "da5b9ce5228d670de1bbc5b8c02441d01358c0a97b0037b17c6a5385c0e14442"
 dependencies = [
  "bitflags",
  "cow-utils",
  "memchr",
  "num-bigint",
  "num-traits",
- "oxc_allocator 0.121.0",
- "oxc_ast 0.121.0",
- "oxc_data_structures 0.121.0",
- "oxc_diagnostics 0.121.0",
- "oxc_ecmascript 0.121.0",
- "oxc_regular_expression 0.121.0",
- "oxc_span 0.121.0",
- "oxc_syntax 0.121.0",
- "rustc-hash",
- "seq-macro",
-]
-
-[[package]]
-name = "oxc_parser"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab4ee6b100bedfd125cfbd9747e921984d6adab212b73affecc29a46df4bf15"
-dependencies = [
- "bitflags",
- "cow-utils",
- "memchr",
- "num-bigint",
- "num-traits",
- "oxc_allocator 0.126.0",
- "oxc_ast 0.126.0",
- "oxc_data_structures 0.126.0",
- "oxc_diagnostics 0.126.0",
- "oxc_ecmascript 0.126.0",
- "oxc_regular_expression 0.126.0",
- "oxc_span 0.126.0",
- "oxc_str 0.126.0",
- "oxc_syntax 0.126.0",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_ecmascript",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
  "rustc-hash",
  "seq-macro",
 ]
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d495c085efbde1d65636497f9d3e3e58151db614a97e313e2e7a837d81865419"
+checksum = "064f938a25efd15884b3e44565b903add1a762398420835a591bf9de41d27ee1"
 dependencies = [
  "bitflags",
- "oxc_allocator 0.121.0",
- "oxc_ast_macros 0.121.0",
- "oxc_diagnostics 0.121.0",
- "oxc_span 0.121.0",
- "phf",
- "rustc-hash",
- "unicode-id-start",
-]
-
-[[package]]
-name = "oxc_regular_expression"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896df45fde44d336df10d3cab46c0cc58697ffa69d446ca4a1b278b8c582972a"
-dependencies = [
- "bitflags",
- "oxc_allocator 0.126.0",
- "oxc_ast_macros 0.126.0",
- "oxc_diagnostics 0.126.0",
- "oxc_span 0.126.0",
- "oxc_str 0.126.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_diagnostics",
+ "oxc_span",
+ "oxc_str",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -457,91 +329,46 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3edcf2bc8bc73cd8d252650737ef48a482484a91709b7f7a5c5ce49305f247e8"
+checksum = "8763b157864021a4a5ded33bd9e620e25d6e20552d11eefa5d3fa707663a3341"
 dependencies = [
  "compact_str",
  "oxc-miette",
- "oxc_allocator 0.121.0",
- "oxc_ast_macros 0.121.0",
- "oxc_estree 0.121.0",
- "oxc_str 0.121.0",
-]
-
-[[package]]
-name = "oxc_span"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5778776c8d0ed52822841324e0dd08c024a3fc1e6dd45895e129dbb14f33f2a"
-dependencies = [
- "compact_str",
- "oxc-miette",
- "oxc_allocator 0.126.0",
- "oxc_ast_macros 0.126.0",
- "oxc_estree 0.126.0",
- "oxc_str 0.126.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_str",
 ]
 
 [[package]]
 name = "oxc_str"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c60f1570f04257d5678a16391f6d18dc805325e7f876b8e176a3a36fe897be"
+checksum = "bf9548a6a9ab4a6227e1d890d7d244a9b5eb427c6b46790c770f5914b565c52b"
 dependencies = [
  "compact_str",
- "hashbrown 0.16.1",
- "oxc_allocator 0.121.0",
- "oxc_estree 0.121.0",
-]
-
-[[package]]
-name = "oxc_str"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc120670ba73a00a9d1412de98ac63b2907551707fe4063d96ee2e44cc75ab56"
-dependencies = [
- "compact_str",
- "hashbrown 0.17.0",
- "oxc_allocator 0.126.0",
- "oxc_estree 0.126.0",
+ "hashbrown",
+ "oxc_allocator",
+ "oxc_estree",
 ]
 
 [[package]]
 name = "oxc_syntax"
-version = "0.121.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a10c19c89298c0b126d12c5f545786405efbad9012d956ebb3190b64b29905a"
+checksum = "57b3eaa2b28010deb7648dbbbce940ea788164db602e6fe09d81792e97706f07"
 dependencies = [
  "bitflags",
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
- "oxc_allocator 0.121.0",
- "oxc_ast_macros 0.121.0",
- "oxc_estree 0.121.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
  "oxc_index",
- "oxc_span 0.121.0",
- "phf",
- "unicode-id-start",
-]
-
-[[package]]
-name = "oxc_syntax"
-version = "0.126.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ca07418ff23061b0be35b8f3ed43291bf29ad23aeb51a0faff71c5acc751c0"
-dependencies = [
- "bitflags",
- "cow-utils",
- "dragonbox_ecma",
- "nonmax",
- "oxc_allocator 0.126.0",
- "oxc_ast_macros 0.126.0",
- "oxc_estree 0.126.0",
- "oxc_index",
- "oxc_span 0.126.0",
- "oxc_str 0.126.0",
+ "oxc_span",
+ "oxc_str",
  "phf",
  "unicode-id-start",
 ]
@@ -711,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "smawk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,21 @@ oxc_span = ">=0.121"
 unsafe_code = "forbid"
 
 [lints.clippy]
-# フルパス使用検出
+# absolute paths
 absolute_paths = "deny"
-# Rustイディオム (RUST.md idioms table)
+# idiomatic iterators
 cast_possible_truncation = "deny"
 redundant_closure_for_method_calls = "deny"
 filter_map_next = "deny"
 flat_map_option = "deny"
 manual_filter_map = "deny"
 manual_find_map = "deny"
-# インポート
+# imports
 wildcard_imports = "deny"
 enum_glob_use = "deny"
-# 文字列
+# strings
 str_to_string = "deny"
-# 引数
+# arguments
 needless_pass_by_value = "deny"
 
 [profile.release]


### PR DESCRIPTION
## 概要

- `oxc_*` (allocator/ast/parser/span + 推移依存: ast_macros/data_structures/diagnostics/ecmascript/estree/regular_expression/str/syntax) を 0.121.0 / 0.126.0 の二重持ちから **0.132.0 単一**に統一
- `hashbrown`: 0.16.1 / 0.17.0 → **0.17.1**、`siphasher`: 1.0.2 → **1.0.3**
- `litmus` git rev を `c564e7a` → `97222db` に更新（litmus が oxc 0.132 に追従したコミット）
- 副次: `Cargo.toml` の clippy lint セクションのコメントを日本語→英語に翻訳（ファイル内の他コメントとの一貫性確保）

`Cargo.toml` の依存制約 (`>=0.121`) は変更なし。lock グラフの整理のみ。

## 動機

`litmus` が oxc 0.132 へ上がったため、`>=0.121` 制約下で gates 側の lock も自動的に 0.132 へ収束した。同一クレートの複数バージョン同居が解消されることでビルド時のコード重複と最終バイナリサイズが縮小する。

## テスト計画

- [x] `cargo check` 通過確認済
- [ ] CI (`cargo clippy --all-targets --all-features -- -D warnings` / `cargo test`) green