### PR TITLE
chore(ci): main で CI を起動するよう trigger を修正し guardrails baseline に揃える

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -18,28 +18,28 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
           components: clippy, rustfmt
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
-
-      - name: Check
-        run: cargo check
-
-      - name: Test
-        run: cargo test
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Clippy
         run: cargo clippy -- -D warnings
 
       - name: Format check
         run: cargo fmt -- --check
+
+      - name: Test
+        run: cargo test
+
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -47,23 +47,29 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-targets: false
 
       - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
+        with:
+          tool: cargo-deny@0.19.6
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
+        with:
+          tool: cargo-audit@0.22.1
 
       - name: Deny check
         run: cargo deny check


### PR DESCRIPTION
## 概要

- `.github/workflows/ci.yml` の `branches:` を `master` → `main` に修正し、main で CI が走るよう復旧
- action SHA pin の最新化と `persist-credentials: false` 付与で #19 (zizmor 導入) の前準備
- `cargo install cargo-deny/cargo-audit` を `taiki-e/install-action` のプリビルトバイナリに置換し security job を高速化
- 重複する `cargo check` step を削除 (`cargo clippy` / `cargo test` でコンパイルが回るため不要)

## 背景

default branch は `main` だが `.github/workflows/ci.yml:5-7` で `branches: [master]` を指定していたため、最近の main マージ (#11 strict clippy lints, #21 oxc 0.132 bump など) は全て CI を bypass していた。`gh run list --branch main --workflow CI` が空で確認済み。

guardrails の `.github/workflows/ci.yml` を baseline として揃える方針。nextest 移行 (#20) は Phase 3 で別 PR とする。

## テスト計画

- [x] ローカル: `cargo fmt -- --check`
- [x] ローカル: `cargo clippy -- -D warnings`
- [x] ローカル: `cargo test` (96 tests passed)
- [ ] CI: この PR で `CI` workflow が起動し、test / security 両 job が green
- [ ] merge 後: `gh run list --branch main --workflow CI` が空でなくなる

## Phase 進行

| Phase | 内容 | 状態 |
| --- | --- | --- |
| 1 | ci.yml baseline (本 PR) | in review |
| 2 | #19 zizmor 導入 | 次 |
| 3 | #20 nextest 移行 | 後続 |
| 4 | #12 dependabot 有効化 | 後続 |
| 5 | #7 release.yml クロスビルド | 後続 |