### PR TITLE
chore(ci): zizmor を導入し label-from-issue ワークフローを刷新

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,5 +1,5 @@
 # Maps Issue Forms dropdown selections to labels.
-# See https://github.com/stefanbuck/advanced-issue-labeler for syntax.
+# See https://github.com/redhat-plumbers-in-action/advanced-issue-labeler for syntax.
 #
 # Per-repo extension: target repos can append additional `policy` entries
 # (e.g. for area:* labels) by editing this file directly. The shared base
@@ -9,12 +9,12 @@ policy:
       - bug.yml
       - feature.yml
     section:
-      - id: priority
-        block-list:
-          - high
-          - medium
-          - low
+      - id: [priority]
+        block-list: []
         label:
-          - priority:high
-          - priority:medium
-          - priority:low
+          - name: 'priority:high'
+            keys: ['high']
+          - name: 'priority:medium'
+            keys: ['medium']
+          - name: 'priority:low'
+            keys: ['low']

--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -7,22 +7,46 @@ on:
       - edited
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Apply priority labels
-        uses: stefanbuck/[email protected]
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
+
+      - name: Parse bug.yml
+        id: parse-bug
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
+        with:
+          template-path: .github/ISSUE_TEMPLATE/bug.yml
+        continue-on-error: true
+
+      - name: Apply labels for bug
+        if: steps.parse-bug.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
+        with:
+          issue-form: ${{ steps.parse-bug.outputs.jsonString }}
           template: bug.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Apply priority labels (feature)
-        uses: stefanbuck/[email protected]
+      - name: Parse feature.yml
+        id: parse-feature
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
         with:
+          template-path: .github/ISSUE_TEMPLATE/feature.yml
+        continue-on-error: true
+
+      - name: Apply labels for feature
+        if: steps.parse-feature.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
+        with:
+          issue-form: ${{ steps.parse-feature.outputs.jsonString }}
           template: feature.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,20 @@
+rules:
+  artipacked:
+    ignore:
+      # build job checkout: no git push, but persist-credentials hardening is
+      # deferred to the release.yml rework (#7)
+      - release.yml:36
+      # update-homebrew job requires HOMEBREW_TAP_TOKEN to be persisted for git push
+      - release.yml:120
+      # update-sentinels job requires SENTINELS_TOKEN to be persisted for git push
+      - release.yml:188
+  cache-poisoning:
+    ignore:
+      # Swatinem/rust-cache in build job; release workflow runs on tag push only,
+      # no PR-driven cache injection path exists for poisoning to reach release artifacts
+      - release.yml:45
+  superfluous-actions:
+    ignore:
+      # softprops/action-gh-release retained for generate_release_notes feature
+      # which gh CLI does not provide equivalently in script step
+      - release.yml:107


### PR DESCRIPTION
## 概要

- `.github/workflows/zizmor.yml` を新規追加し、GitHub Actions の supply-chain 監査を main への push / PR で実行
- `.github/workflows/label-from-issue.yml` を guardrails と同じ parse + label の 2-stage パターンに刷新
- `.github/advanced-issue-labeler.yml` を `redhat-plumbers-in-action` syntax に揃え、共有 template (thkt/github-labels) との乖離を解消
- `.github/zizmor.yml` で release.yml の既知 finding を justification 付き ignore (Phase 5 で release.yml 刷新時に再評価)

## 背景

Phase 2 として #19 (zizmor 導入) に着手したところ、ローカル `zizmor .github/workflows/` が `.github/workflows/label-from-issue.yml` の `stefanbuck/[email protected]` を解析できず (`@<ref>` 形式不正で `fatal: no audit was performed` で停止) 、audit 全体がブロックされていることが判明した。

`label-from-issue.yml` は元々 main で 2 回 failure (`gh run list` 確認済み) しており、共有 template (`thkt/github-labels`) は既に `redhat-plumbers-in-action/advanced-issue-labeler@v2` に移行済みだったため、gates だけが古い syntax のまま取り残されていた状態。

guardrails が先行して同等の刷新を完了しているため、guardrails の workflow / config を SHA pin 込みでそのまま揃える。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `.github/workflows/zizmor.yml` | 新規。`zizmorcore/zizmor-action@v0.5.3` (SHA pin)、`permissions: {}` 起点、`security-events: write` を job レベルで付与 |
| `.github/zizmor.yml` | 新規。release.yml の `artipacked` × 3 / `cache-poisoning` × 1 / `superfluous-actions` × 1 を justification 付きで ignore |
| `.github/workflows/label-from-issue.yml` | 刷新。`stefanbuck/github-issue-parser@v3` で issue body を parse し、`redhat-plumbers-in-action/advanced-issue-labeler@v3.2.4` で label 付与。全 action を SHA pin、`persist-credentials: false` 付与 |
| `.github/advanced-issue-labeler.yml` | `redhat-plumbers-in-action` 形式 (`id: [priority]` + `label: [{name, keys}]`) に変更し github-labels と統一 |

## テスト計画

- [x] ローカル: `zizmor .github/workflows/` → `No findings to report. Good job! (5 ignored, 20 suppressed)`
- [ ] CI: 本 PR で `zizmor` workflow が起動し green
- [ ] CI: 既存の `CI` workflow も引き続き green (本 PR で workflow 構造は変えていないため影響軽微)
- [ ] merge 後の新規 issue 起票で `label-from-issue` workflow が成功し、`priority:high/medium/low` が自動付与される

## Phase 進行

| Phase | 内容 | 状態 |
| --- | --- | --- |
| 1 | ci.yml baseline | #22 merged |
| 2 | zizmor + label-from-issue (本 PR) | in review |
| 3 | #20 nextest 移行 | 次 |
| 4 | #12 dependabot 有効化 | 後続 |
| 5 | #7 release.yml クロスビルド刷新 | 後続 |

Closes #19