### PR TITLE
chore(ci): cargo test を cargo nextest run --profile ci に移行

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,9 @@
+[profile.default]
+fail-fast = false
+
+[profile.ci]
+fail-fast = false
+# Default 60s is too tight for cold CI runs; allow 2 grace periods before killing (max 240s).
+slow-timeout = { period = "120s", terminate-after = 2 }
+# Surface flaky tests in the final report so retries don't hide intermittent failures.
+final-status-level = "flaky"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Install nextest
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
+        with:
+          tool: cargo-nextest
+
       - name: Clippy
         run: cargo clippy -- -D warnings
 
@@ -38,7 +43,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Test
-        run: cargo test
+        run: cargo nextest run --profile ci
 
   security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

- `.config/nextest.toml` を新規追加し、CI 用の nextest profile (`ci`) を定義
- `.github/workflows/ci.yml` の Test step を `cargo nextest run --profile ci` に置換
- `cargo-nextest` は `taiki-e/install-action` でプリビルトバイナリを install

## 背景

cli 配下の Rust リポでは `cargo test` → `cargo nextest run` 移行を rurico (thkt/rurico@17c10f5) で着手し、guardrails が追従済み。gates も同じパターンで横展開する。

利点:
- テスト並列化による wall time 短縮
- per-test 進捗と flaky 検出 (`final-status-level: flaky`)
- `slow-timeout` (120s × 2 grace) で CI の遅いランナーでも誤検知を抑制

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `.config/nextest.toml` | 新規。`profile.default` / `profile.ci` の 2 profile、コメントで `slow-timeout` と `final-status-level` の選定理由を併記 |
| `.github/workflows/ci.yml` | `Install nextest` step を `taiki-e/install-action@v2.78.2` で追加し、Test step の `cargo test` を `cargo nextest run --profile ci` に置換 |

doctest は src 配下に存在しないため `cargo test --doc` step は追加していない。今後 doctest を増やす場合は別 step で対応する想定。

## テスト計画

- [x] ローカル: `cargo nextest run --profile ci` → 96 tests run, 96 passed, 0 skipped (0.895s)
- [x] ローカル: `cargo fmt -- --check` ✓
- [x] ローカル: `cargo clippy -- -D warnings` ✓
- [ ] CI: 本 PR で test job が green
- [ ] CI: zizmor も引き続き green (workflow 構造変更が zizmor finding を生まないこと)

## Phase 進行

| Phase | 内容 | 状態 |
| --- | --- | --- |
| 1 | ci.yml baseline | #22 merged |
| 2 | zizmor + label-from-issue | #23 merged |
| 3 | nextest 移行 (本 PR) | in review |
| 4 | #12 dependabot 有効化 | 次 |
| 5 | #7 release.yml クロスビルド刷新 | 後続 |

Closes #20