### PR TITLE
chore(ci): dependabot を有効化し github-actions / cargo を weekly 更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      patch-and-minor:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## 概要

- `.github/dependabot.yml` を新規追加
- 監視対象: `github-actions` (全 workflow の SHA pin) と `cargo` (Cargo.lock)
- スケジュール: weekly、cooldown (major 14d / minor 7d / patch 3d / default 7d) で hot-off-the-press 版を回避
- cargo の minor/patch は `patch-and-minor` group で 1 PR にまとめ、major は個別 PR

## 背景

cli 配下の Rust リポでは依存自動更新を amici (thkt/amici#25) → guardrails の順で展開済み。gates も追従して pin 老朽化とセキュリティアラート抜け漏れを回避する。

特に Phase 1 / Phase 2 で `.github/workflows/*.yml` の action SHA を厳格に pin した今、人手で SHA を追従するコストが高くなる。dependabot が patch/minor を group 1 PR で持ってきてくれることで、手動 bump 作業を圧縮できる。

## 変更内容

| 項目 | 設定 |
| --- | --- |
| `github-actions` | weekly、ラベル `dependencies` / `ci`、cooldown 7-14d |
| `cargo` | weekly、ラベル `dependencies` / `rust`、cooldown 7-14d、`patch-and-minor` group |
| `commit-message` | `chore(...)` prefix + include scope |

ラベル `dependencies` / `ci` / `rust` は既に repository に存在 (`gh label list` で確認済み) のため追加作成不要。

## テスト計画

- [x] ローカル: `.github/dependabot.yml` の文法確認 (yaml 構造)
- [ ] merge 後: 次の月曜 (UTC) に dependabot が PR を立てるか観察
- [ ] merge 後: 立った PR が想定どおりのラベル (`dependencies` + `ci` / `rust`) を付与しているか

## Phase 進行

| Phase | 内容 | 状態 |
| --- | --- | --- |
| 1 | ci.yml baseline | #22 merged |
| 2 | zizmor + label-from-issue | #23 merged |
| 3 | nextest 移行 | #24 merged |
| 4 | dependabot 有効化 (本 PR) | in review |
| 5 | #7 release.yml クロスビルド刷新 | 次 |

Closes #12