### PR TITLE
chore(ci): release.yml の action SHA pin を guardrails 同等に更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,16 +33,18 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: ${{ matrix.target }}
 
@@ -71,7 +73,7 @@ jobs:
           tar czf "$NAME.tar.gz" gates
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.name }}
           path: ${{ matrix.name }}.*
@@ -99,12 +101,12 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: artifacts/**/*
           generate_release_notes: true
@@ -118,13 +120,13 @@ jobs:
 
     steps:
       - name: Checkout homebrew-tap
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: thkt/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Download artifacts for checksums
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
@@ -186,7 +188,7 @@ jobs:
 
     steps:
       - name: Checkout sentinels
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: thkt/sentinels
           token: ${{ secrets.SENTINELS_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,20 +1,17 @@
 rules:
   artipacked:
     ignore:
-      # build job checkout: no git push, but persist-credentials hardening is
-      # deferred to the release.yml rework (#7)
-      - release.yml:36
       # update-homebrew job requires HOMEBREW_TAP_TOKEN to be persisted for git push
-      - release.yml:120
+      - release.yml:122
       # update-sentinels job requires SENTINELS_TOKEN to be persisted for git push
-      - release.yml:188
+      - release.yml:190
   cache-poisoning:
     ignore:
       # Swatinem/rust-cache in build job; release workflow runs on tag push only,
       # no PR-driven cache injection path exists for poisoning to reach release artifacts
-      - release.yml:45
+      - release.yml:47
   superfluous-actions:
     ignore:
       # softprops/action-gh-release retained for generate_release_notes feature
       # which gh CLI does not provide equivalently in script step
-      - release.yml:107
+      - release.yml:109


### PR DESCRIPTION
## 概要

- `.github/workflows/release.yml` の全アクション SHA pin を cli/* で最新の baseline に更新
- build job の `actions/checkout` に `persist-credentials: false` を追加
- `.github/zizmor.yml` の `release.yml:36` ignore を削除し、残りの行番号ずれも反映
- ローカル `zizmor .github/workflows/` で No findings (4 ignored, 1 縮減)

## 背景

issue #7 の受け入れ条件 (release.yml 追加 / `v*` トリガー / `gates-{target}` 命名 / `cargo build --release --target`) は **すべて達成済み**で、v0.4.0 〜 v0.10.1 まで 10 個の release を運用中。一方 release.yml の action SHA pin が古く、Phase 2 で zizmor を導入した際に finding 5 件を `.github/zizmor.yml` で ignore する応急処置を取っていた。

本 PR は SHA pin を guardrails と同等まで現代化し、ignore の縮減 (とくに `build job:36` は本質解消) を行う。

## cli/* 横並びの参考

| 機能 | gates 現状 | 採用リポ |
| --- | --- | --- |
| 最新 checkout SHA (`@v6.0.2` 系) | 旧 v4 | chronicler / notch / recall / scout / shields / yomu / guardrails (7/12) |
| Windows target | なし | formatter / guardrails (2/12) |
| GitHub App token (`create-github-app-token`) | なし | guardrails のみ (1/12) |
| `publish-binaries-to-sentinels` job | なし | guardrails のみ (1/12) |

本 PR は **SHA pin 更新だけを横展開**する。Windows / App token / publish-binaries は cli/* で標準化されていないため横展開対象外とし、必要時に別途検討する (follow-up issue 化候補)。

## 変更内容

| アクション | 旧 | 新 |
| --- | --- | --- |
| `actions/checkout` (× 3) | v4 | v6.0.2 |
| `dtolnay/rust-toolchain` | 旧 SHA | 新 SHA (stable) |
| `Swatinem/rust-cache` | v2.7.8 | v2.9.1 |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `actions/download-artifact` (× 2) | v4 | v8.0.1 |
| `softprops/action-gh-release` | v2.2.2 | v3.0.0 |

build job の checkout に `persist-credentials: false` を付与 (`git push` しないビルダーなのでクレデンシャル無効化が安全)。

`.github/zizmor.yml` の更新:
- `release.yml:36` (build job checkout) ignore を削除 (persist-credentials 設定で本質解消)
- 行番号ずれ反映: 120→122 (homebrew) / 188→190 (sentinels) / 45→47 (rust-cache) / 107→109 (action-gh-release)

## テスト計画

- [x] ローカル: `zizmor .github/workflows/` → No findings (4 ignored, 20 suppressed)
- [ ] CI: 本 PR で zizmor workflow が green
- [ ] CI: 既存の `CI` workflow が green
- [ ] 次回タグ push (`v*`) で release workflow が引き続き 4 ターゲット (mac arm64/x86_64 + linux arm64/amd64) のバイナリを正常添付

## Phase 進行

| Phase | 内容 | 状態 |
| --- | --- | --- |
| 1 | ci.yml baseline | #22 merged |
| 2 | zizmor + label-from-issue | #23 merged |
| 3 | nextest 移行 | #24 merged |
| 4 | dependabot 有効化 | #25 merged |
| 5 | release.yml SHA pin (本 PR) | in review |

これで `ci` ラベル open issue 4 件 (#7 / #12 / #19 / #20) は全て対応完了。

Closes #7