### PR TITLE
chore(ci): oxc_* の Dependabot 更新を単一 PR にグループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
       prefix: chore
       include: scope
     groups:
+      oxc:
+        patterns:
+          - "oxc*"
       patch-and-minor:
         update-types:
           - minor


### PR DESCRIPTION
## 概要
`dependabot.yml` に `oxc` グループを追加し、全 `oxc_*` crate を単一 PR でまとめて更新する。

## 理由
`oxc_*` crate は密結合で単一バージョンを共有する必要がある。crate ごとに個別 bump すると残りが旧バージョンのまま残り、`error[E0308]: mismatched types` でコンパイル不能になる（guardrails で #209/#211/#212/#213 が実際に CI 失敗し、#214 で同じ対応を実施）。

`patterns: ["oxc*"]` グループは update-type に依存せず oxc_* をまとめるため常に一括更新される。gates も oxc_parser ベースで同一リスクを持つため予防的に適用する。