### PR TITLE
ci: coverage delta gate を追加 (cli 横断展開 / base-vs-head C0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,66 @@ jobs:
       - name: Test
         run: cargo nextest run --profile ci
 
+  coverage:
+    # Coverage delta gate: fail when project line coverage (C0) drops vs main.
+    # Measures base-vs-head total C0, not diff-cover changed-lines: a changed-
+    # lines gate false-fails move-only refactors (relocated tested lines look
+    # "new and uncovered"), while base-vs-head cancels relocations out and still
+    # catches genuinely new untested code. No absolute floor, so existing
+    # unreachable code is never flagged (only a drop vs main fails).
+    # test_utils.rs is excluded (--ignore-filename-regex): it is a #[cfg(test)]
+    # helper, so the gate measures production-line coverage only.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Coverage delta gate (project C0 must not drop vs main)
+        run: |
+          set -euo pipefail
+          # Sum LH (lines hit) / LF (lines found) across an lcov report -> C0 %.
+          c0() { awk -F: '/^LF:/{f+=$2} /^LH:/{h+=$2} END{ if (f==0) print "100.0"; else printf "%.4f", h*100/f }' "$1"; }
+          # HEAD = PR merged into main (the checked-out pull_request ref).
+          # cargo llvm-cov cleans stale profraw at the start of each run, so the
+          # two measurements below do not mix.
+          cargo llvm-cov --ignore-filename-regex 'src/test_utils\.rs$' --lcov --output-path head.info
+          head_c0=$(c0 head.info)
+          # BASE = main (fetch-depth:0 already has the history).
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git checkout --quiet --force origin/main
+          cargo llvm-cov --ignore-filename-regex 'src/test_utils\.rs$' --lcov --output-path base.info
+          base_c0=$(c0 base.info)
+          # 0.1pp tolerance absorbs instrumentation rounding / total line drift.
+          awk -v b="$base_c0" -v h="$head_c0" 'BEGIN {
+            printf "C0 coverage: main %.2f%% -> PR %.2f%%\n", b, h
+            if (h + 0.1 < b) {
+              printf "::error::C0 coverage dropped %.2f%% -> %.2f%% (tolerance 0.1pp)\n", b, h
+              exit 1
+            }
+            print "OK: coverage did not drop"
+          }'
+
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 docs/
 target/
 workspace/
+
+# Coverage artifacts (cargo llvm-cov)
+*.profraw
+/*.info


### PR DESCRIPTION
## 概要

cli/ 配下への coverage gate 横断展開の一環として gates に coverage job を追加する (Issue #33)。PR でプロジェクト全体の行カバレッジ (C0) が main を下回ると fail し、未テストの新規 `pub fn` / 分岐の merge を防ぐ。絶対 floor は持たない (到達不可コードを誤検知しない)。

Closes #33

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `.github/workflows/ci.yml` | test job と security job の間に `coverage` job を追加 (base-vs-head 全体 C0 delta) |
| `.gitignore` | coverage 生成物 `*.profraw` / `/*.info` を追加 |

## 設計判断

**diff-cover ではなく base-vs-head 全体 C0 delta を採用**

Issue #33 は当初 diff-cover (変更行 95%) を指定していたが、テンプレ元の guardrails が #33 作成の約3時間後に move-only PR の誤検知 (thkt/guardrails#227 / #232) を理由に base-vs-head 方式へ切替済み。diff-cover は move-only refactor で「移動した既テスト行＝新規未カバー」と誤判定するため、成熟版の base-vs-head を採用した。Python 依存も不要。

**test_utils.rs を計測から除外**

`test_utils.rs` は `#[cfg(test)]` ヘルパーのため `--ignore-filename-regex 'src/test_utils\.rs$'` で除外し、production 行のみ計測する (production C0=94.02%)。

## 検証手順

1. この PR の CI で `coverage` job が pass することを確認 (Rust 変更ゼロ → main と PR の C0 が一致 → "OK: coverage did not drop")
2. ローカル検証済み: `actionlint` OK / YAML パース (job 順 test→coverage→security) / ゲート両パス (同値→pass, 低下→exit 1) / 実 `cargo llvm-cov` クリーンビルド

## レビュー観点

- coverage job の挿入位置 (test と security の間) と SHA pin が既存 job と一致しているか
- `test_utils.rs` 除外の妥当性 (production-only 計測の意図)