### PR TITLE
[機能] アーキテクチャ境界違反検出のための dependency-cruiser ゲート追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 # gates
 
-Claude Codeの[PostToolUseフック](https://docs.anthropic.com/en/docs/claude-code/hooks)用品質ゲート。lint・type-check・test・knip・tsgo・litmus・循環依存検出をWrite/Edit/MultiEditのたびに並列実行し、失敗時にエージェントへフィードバックを返します。
+Claude Codeの[PostToolUseフック](https://docs.anthropic.com/en/docs/claude-code/hooks)用品質ゲート。lint・type-check・test・knip・tsgo・dependency-cruiser・litmus・循環依存検出をWrite/Edit/MultiEditのたびに並列実行し、失敗時にエージェントへフィードバックを返します。
 
 ## 特徴
 
@@ -33,10 +33,11 @@ Claude Codeの[PostToolUseフック](https://docs.anthropic.com/en/docs/claude-c
 
 `node_modules/.bin` から解決し、見つからなければ `$PATH` にフォールバックします。
 
-| ゲート | 条件                 | 引数     |
-| ------ | -------------------- | -------- |
-| knip   | `package.json` あり  | （なし） |
-| tsgo   | `tsconfig.json` あり | （なし） |
+| ゲート    | 条件                                         | 引数     |
+| --------- | -------------------------------------------- | -------- |
+| knip      | `package.json` あり                          | （なし） |
+| tsgo      | `tsconfig.json` あり                         | （なし） |
+| depcruise | `.dependency-cruiser.{js,cjs,mjs,json}` あり | `src/`   |
 
 ### 組み込みゲート
 
@@ -63,10 +64,11 @@ Claude Codeの[PostToolUseフック](https://docs.anthropic.com/en/docs/claude-c
 
 使いたいゲートに対応するツールをインストールしてください。
 
-| ツール                                             | インストール                                |
-| -------------------------------------------------- | ------------------------------------------- |
-| [knip](https://knip.dev)                           | `npm i -D knip`（プロジェクトローカル推奨） |
-| [tsgo](https://github.com/microsoft/typescript-go) | `npm i -g @typescript/native-preview`       |
+| ツール                                                               | インストール                                              |
+| -------------------------------------------------------------------- | --------------------------------------------------------- |
+| [knip](https://knip.dev)                                             | `npm i -D knip`（プロジェクトローカル推奨）               |
+| [tsgo](https://github.com/microsoft/typescript-go)                   | `npm i -g @typescript/native-preview`                     |
+| [dependency-cruiser](https://github.com/sverweij/dependency-cruiser) | `npm i -D dependency-cruiser`（プロジェクトローカル推奨） |
 
 [litmus](https://github.com/thkt/litmus) と循環依存検出は `gates` バイナリに内蔵されています。個別インストールは不要です。
 
@@ -167,6 +169,7 @@ gates /path/to/project  # ディレクトリを明示指定
   "gates": {
     "knip": true,
     "tsgo": true,
+    "depcruise": true,
     "circular": true,
     "litmus": true,
     "lint": true,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gates
 
-Quality gates for Claude Code [PostToolUse hooks](https://docs.anthropic.com/en/docs/claude-code/hooks). Runs lint, type-check, test, knip, tsgo, litmus, and circular dependency detection in parallel after each Write/Edit/MultiEdit, providing failure feedback to guide the agent.
+Quality gates for Claude Code [PostToolUse hooks](https://docs.anthropic.com/en/docs/claude-code/hooks). Runs lint, type-check, test, knip, tsgo, dependency-cruiser, litmus, and circular dependency detection in parallel after each Write/Edit/MultiEdit, providing failure feedback to guide the agent.
 
 ## Features
 
@@ -33,10 +33,11 @@ Agent calls Write/Edit/MultiEdit → PostToolUse hook fires → gates binary run
 
 Resolved from `node_modules/.bin`, falling back to `$PATH`.
 
-| Gate | Condition              | Args   |
-| ---- | ---------------------- | ------ |
-| knip | `package.json` exists  | (none) |
-| tsgo | `tsconfig.json` exists | (none) |
+| Gate      | Condition                                      | Args   |
+| --------- | ---------------------------------------------- | ------ |
+| knip      | `package.json` exists                          | (none) |
+| tsgo      | `tsconfig.json` exists                         | (none) |
+| depcruise | `.dependency-cruiser.{js,cjs,mjs,json}` exists | `src/` |
 
 ### Embedded Gates
 
@@ -63,10 +64,11 @@ When no lock file is found, script gates are silently skipped (fail-open). Envir
 
 Install the tools for the gates you want to use.
 
-| Tool                                               | Install                               |
-| -------------------------------------------------- | ------------------------------------- |
-| [knip](https://knip.dev)                           | `npm i -D knip` (project-local)       |
-| [tsgo](https://github.com/microsoft/typescript-go) | `npm i -g @typescript/native-preview` |
+| Tool                                                                 | Install                                       |
+| -------------------------------------------------------------------- | --------------------------------------------- |
+| [knip](https://knip.dev)                                             | `npm i -D knip` (project-local)               |
+| [tsgo](https://github.com/microsoft/typescript-go)                   | `npm i -g @typescript/native-preview`         |
+| [dependency-cruiser](https://github.com/sverweij/dependency-cruiser) | `npm i -D dependency-cruiser` (project-local) |
 
 [litmus](https://github.com/thkt/litmus) and circular dependency detection are embedded in the `gates` binary — no separate installation needed.
 
@@ -167,6 +169,7 @@ When no config file exists, all gates run by default. Once you create `.claude/t
   "gates": {
     "knip": true,
     "tsgo": true,
+    "depcruise": true,
     "circular": true,
     "litmus": true,
     "lint": true,
@@ -212,12 +215,12 @@ different phase — install the full suite for comprehensive coverage:
 brew install thkt/tap/guardrails thkt/tap/formatter thkt/tap/reviews thkt/tap/gates
 ```
 
-| Tool                                             | Hook        | Timing            | Role                               |
-| ------------------------------------------------ | ----------- | ----------------- | ---------------------------------- |
-| [guardrails](https://github.com/thkt/guardrails) | PreToolUse  | Before Write/Edit | Lint + security checks             |
-| [formatter](https://github.com/thkt/formatter)   | PostToolUse | After Write/Edit  | Auto code formatting               |
-| [reviews](https://github.com/thkt/reviews)       | PreToolUse  | Before Skill      | Static analysis context injection  |
-| **gates**                                        | PostToolUse | After Write/Edit  | Quality gates                      |
+| Tool                                             | Hook        | Timing            | Role                              |
+| ------------------------------------------------ | ----------- | ----------------- | --------------------------------- |
+| [guardrails](https://github.com/thkt/guardrails) | PreToolUse  | Before Write/Edit | Lint + security checks            |
+| [formatter](https://github.com/thkt/formatter)   | PostToolUse | After Write/Edit  | Auto code formatting              |
+| [reviews](https://github.com/thkt/reviews)       | PreToolUse  | Before Skill      | Static analysis context injection |
+| **gates**                                        | PostToolUse | After Write/Edit  | Quality gates                     |
 
 See [thkt/tap](https://github.com/thkt/homebrew-tap) for setup details.
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -103,6 +103,20 @@ pub const GATES: &[GateDefinition] = &[
         hint: "Fix type errors.",
         condition: |p| p.has_tsconfig,
     },
+    // dependency-cruiser auto-detects .dependency-cruiser.{js,cjs,mjs,json} since v13,
+    // so --config is omitted; the condition gates on the same four formats it detects.
+    // https://github.com/sverweij/dependency-cruiser/blob/main/doc/cli.md
+    GateDefinition {
+        name: "depcruise",
+        command: "dependency-cruiser",
+        args: &["src/"],
+        hint: "Fix architecture boundary violations.",
+        condition: |p| {
+            ["js", "cjs", "mjs", "json"]
+                .iter()
+                .any(|ext| p.root.join(format!(".dependency-cruiser.{ext}")).exists())
+        },
+    },
 ];
 
 pub struct ScriptGate {
@@ -733,6 +747,64 @@ mod tests {
 
         assert!(!(gate_by_name("tsgo").condition)(&pkg_only));
         assert!((gate_by_name("tsgo").condition)(&ts_only));
+    }
+
+    fn depcruise_project_with(config: Option<&str>) -> (TempDir, ProjectInfo) {
+        let tmp = TempDir::new("depcruise");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        if let Some(name) = config {
+            fs::write(tmp.join(name), "module.exports = {};").unwrap();
+        }
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: false,
+            has_tsconfig: false,
+        };
+        (tmp, project)
+    }
+
+    #[test]
+    fn depcruise_condition_true_with_js_config() {
+        let (_tmp, project) = depcruise_project_with(Some(".dependency-cruiser.js"));
+        assert!((gate_by_name("depcruise").condition)(&project));
+    }
+
+    #[test]
+    fn depcruise_condition_true_with_cjs_config() {
+        let (_tmp, project) = depcruise_project_with(Some(".dependency-cruiser.cjs"));
+        assert!((gate_by_name("depcruise").condition)(&project));
+    }
+
+    #[test]
+    fn depcruise_condition_true_with_mjs_config() {
+        let (_tmp, project) = depcruise_project_with(Some(".dependency-cruiser.mjs"));
+        assert!((gate_by_name("depcruise").condition)(&project));
+    }
+
+    #[test]
+    fn depcruise_condition_true_with_json_config() {
+        let (_tmp, project) = depcruise_project_with(Some(".dependency-cruiser.json"));
+        assert!((gate_by_name("depcruise").condition)(&project));
+    }
+
+    #[test]
+    fn depcruise_condition_false_without_config() {
+        let (_tmp, project) = depcruise_project_with(None);
+        assert!(!(gate_by_name("depcruise").condition)(&project));
+    }
+
+    #[test]
+    fn depcruise_skips_without_config() {
+        let (_tmp, project) = depcruise_project_with(None);
+        let result = run_gate(gate_by_name("depcruise"), &project);
+        assert!(result.is_skipped(), "depcruise should skip without config");
+    }
+
+    #[test]
+    fn depcruise_definition_uses_auto_detect() {
+        let gate = gate_by_name("depcruise");
+        assert_eq!(gate.command, "dependency-cruiser");
+        assert_eq!(gate.args, &["src/"]);
     }
 
     #[test]


### PR DESCRIPTION
## 概要と目的

gates に dependency-cruiser ゲートを追加し、方向性のあるアーキテクチャ境界違反（例: domain 層が UI 層を import）を検出できるようにする。既存の circular ゲートは import の循環のみを検出し、方向性のある違反は検出できなかった。dependency-cruiser がこの gap を埋める。

## 変更点

- `src/tools.rs` の `GATES` に `depcruise` ゲートを追加。`.dependency-cruiser.{js,cjs,mjs,json}` のいずれかが存在する場合に有効化し、`dependency-cruiser src/` を実行
- main.rs は GATES を自動イテレートするため実行配線の追加は不要。fail-open（バイナリ不在・タイムアウトで skip）は既存 `run_gate` が担保
- テスト6件追加（4形式の condition true / 設定なしで false・skip / 定義値の検証）
- README.md / README.ja.md のゲート一覧・設定例に depcruise を追記

## 設計判断

- `--config` を渡さず depcruise の自動検出（v13+）に委ねる。`.cjs` のみ等の非 .js 設定プロジェクトで `--config .dependency-cruiser.js` を渡すと存在しないファイルを指して誤ブロック（fail-open 違反）になるため
- condition は depcruise が自動検出する4形式（js/cjs/mjs/json）すべてを対象とする。Issue AC#2 の字面（js/cjs）からは拡張だが、自動検出方針の自然な完成で silent skip を防ぐ
- ゲートの config キー / 表示名は `depcruise`、npm パッケージ名は `dependency-cruiser`

## テスト方法

1. `cargo test` → 103 件 pass（depcruise 関連6件含む）
2. `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` → クリーン
3. `.dependency-cruiser.js` と違反ルールを持つ TS プロジェクトで gates を実行 → depcruise が非ゼロ終了しブロック

## 関連

- Closes #2

https://claude.ai/code/session_01Qe2gb9VKEsgJKL4ZxmAivQ