### PR TITLE
[Feature] oxc AST ハッシュを用いた構造的コードクローン検出ゲートの追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "castaway"
@@ -55,6 +58,7 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -204,7 +208,9 @@ dependencies = [
  "allocator-api2",
  "hashbrown",
  "oxc_data_structures",
+ "oxc_estree",
  "rustc-hash",
+ "serde",
 ]
 
 [[package]]
@@ -275,6 +281,11 @@ name = "oxc_estree"
 version = "0.137.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6c062d52b9ff15d118b87679bdd0a05c43599c1d55fd1cab280da1cc822858"
+dependencies = [
+ "dragonbox_ecma",
+ "itoa",
+ "oxc_data_structures",
+]
 
 [[package]]
 name = "oxc_index"
@@ -339,6 +350,7 @@ dependencies = [
  "oxc_ast_macros",
  "oxc_estree",
  "oxc_str",
+ "serde",
 ]
 
 [[package]]
@@ -351,6 +363,7 @@ dependencies = [
  "hashbrown",
  "oxc_allocator",
  "oxc_estree",
+ "serde",
 ]
 
 [[package]]
@@ -370,6 +383,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "phf",
+ "serde",
  "unicode-id-start",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = ">=1"
 regex = ">=1"
 litmus = { git = "https://github.com/thkt/litmus.git" }
 oxc_allocator = ">=0.121"
-oxc_ast = ">=0.121"
+oxc_ast = { version = ">=0.121", features = ["serialize"] }
 oxc_parser = ">=0.121"
 oxc_span = ">=0.121"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gates
 
-Quality gates for Claude Code [PostToolUse hooks](https://docs.anthropic.com/en/docs/claude-code/hooks). Runs lint, type-check, test, knip, tsgo, dependency-cruiser, litmus, circular dependency detection, and coupling metrics in parallel after each Write/Edit/MultiEdit, providing failure feedback to guide the agent.
+Quality gates for Claude Code [PostToolUse hooks](https://docs.anthropic.com/en/docs/claude-code/hooks). Runs lint, type-check, test, knip, tsgo, dependency-cruiser, litmus, circular dependency detection, coupling metrics, and structural clone detection in parallel after each Write/Edit/MultiEdit, providing failure feedback to guide the agent.
 
 ## Features
 
@@ -48,6 +48,7 @@ Built into the `gates` binary. No separate installation required.
 | litmus   | `package.json` + `*.test.ts/tsx` exists              | Weak assertions, mock overuse, tautological tests                  |
 | circular | `package.json` + `src/` exists                       | Circular import dependencies (oxc-based AST)                       |
 | coupling | `package.json` + `src/` + `coupling.caThreshold` set | God modules (Ca > threshold) via Ca/Ce/instability (oxc-based AST) |
+| clone    | `package.json` + `src/` exists                       | Type 1/2 structural code clones via oxc AST hashing                |
 
 ### Script Gates
 
@@ -189,6 +190,23 @@ The coupling gate flags God modules whose afferent coupling (Ca, the number of i
 {
   "gates": { "coupling": true },
   "coupling": { "caThreshold": 20 }
+}
+```
+
+### Clone Thresholds
+
+The clone gate hashes the oxc AST of every `src/` file to find Type 1 (whitespace-normalized identical) and Type 2 (structurally identical, identifiers and literals differ) duplicate subtrees, then blocks once the number of clone groups reaches `clone.blockThreshold`. All three keys are optional and fall back to the defaults below.
+
+| Key                    | Default | Meaning                                                     |
+| ---------------------- | ------- | ----------------------------------------------------------- |
+| `clone.minNodes`       | 20      | Minimum AST node count for a subtree to count as a clone    |
+| `clone.minLines`       | 5       | Minimum line span of the largest copy for a group to report |
+| `clone.blockThreshold` | 3       | Number of clone groups that triggers a block                |
+
+```json
+{
+  "gates": { "clone": true },
+  "clone": { "minNodes": 20, "minLines": 5, "blockThreshold": 3 }
 }
 ```
 

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -241,7 +241,15 @@ fn render(value: &Value, ctx: &mut WalkCtx) -> Rendered {
     match value {
         Value::Object(map) => match map.get("type") {
             Some(Value::String(ty)) => render_node(map, ty, ctx),
-            _ => render_plain_object(map, ctx),
+            // Non-node objects (the regex `{pattern,flags}` payload, template
+            // `{cooked,raw}`) are stringified by render_node via CONTENT_KEYS
+            // before reaching render(), so this arm is not hit in practice; an
+            // empty render keeps the match total and degrades gracefully.
+            _ => Rendered {
+                named: String::new(),
+                blank: String::new(),
+                count: 0,
+            },
         },
         Value::Array(arr) => {
             let mut named = String::from("[");
@@ -322,38 +330,6 @@ fn render_node(map: &Map<String, Value>, ty: &str, ctx: &mut WalkCtx) -> Rendere
             end_line,
         });
     }
-    Rendered {
-        named,
-        blank,
-        count,
-    }
-}
-
-/// A `type`-less object (e.g. a regex `{pattern,flags}` payload). Rendered
-/// structurally but never recorded as a clone candidate.
-fn render_plain_object(map: &Map<String, Value>, ctx: &mut WalkCtx) -> Rendered {
-    let mut keys: Vec<&String> = map
-        .keys()
-        .filter(|k| !matches!(k.as_str(), "start" | "end" | "range"))
-        .collect();
-    keys.sort();
-    let mut named = String::from("{");
-    let mut blank = String::from("{");
-    let mut count = 0;
-    for k in keys {
-        let r = render(&map[k], ctx);
-        named.push_str(k);
-        named.push(':');
-        named.push_str(&r.named);
-        named.push(',');
-        blank.push_str(k);
-        blank.push(':');
-        blank.push_str(&r.blank);
-        blank.push(',');
-        count += r.count;
-    }
-    named.push('}');
-    blank.push('}');
     Rendered {
         named,
         blank,
@@ -540,5 +516,27 @@ mod tests {
             "the clone survives because one copy spans >= min_lines"
         );
         assert_eq!(result.groups[0].instances.len(), 2);
+    }
+
+    // T-613: a regex literal carries a type-less `{pattern,flags}` payload.
+    // render_node stringifies it via CONTENT_KEYS, so regex-containing functions
+    // still group as a clone rather than being walked structurally.
+    #[test]
+    fn renders_regex_payload_in_clone_path() {
+        let src = "export function validate(input: string) {\n  const re = /ab+c/gi;\n  const ok = re.test(input);\n  const trimmed = input.trim();\n  return ok && trimmed.length > 0;\n}\n";
+        let result = analyze_files(&[("a.ts", src), ("b.ts", src)], 5, 5);
+        assert_eq!(
+            result.groups.len(),
+            1,
+            "identical regex-containing functions form one clone group"
+        );
+    }
+
+    // T-614: an unreadable input path is skipped, not fatal.
+    #[test]
+    fn skips_unreadable_files() {
+        let missing = PathBuf::from("/nonexistent/does-not-exist.ts");
+        let result = analyze(&[missing], Path::new("/nonexistent"), 5, 5);
+        assert_eq!(result.groups.len(), 0);
     }
 }

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -1,0 +1,544 @@
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use serde_json::{Map, Value};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::depgraph::display_path;
+
+/// Default minimum AST node count for a subtree to be considered a clone unit.
+pub const DEFAULT_MIN_NODES: usize = 20;
+/// Default minimum source line span for a clone unit.
+pub const DEFAULT_MIN_LINES: usize = 5;
+/// Default number of clone groups that triggers a block (DRY rule of three).
+pub const DEFAULT_BLOCK_THRESHOLD: usize = 3;
+
+/// ESTree node types whose identifier/literal *content* is normalized away when
+/// computing the Type 2 (structural) key, so renamed identifiers and differing
+/// literals hash equal. Gated by node type — not key name — so structural fields
+/// that merely share a name (e.g. `Property.value`) are never blanked.
+const CONTENT_TYPES: &[&str] = &[
+    "Identifier",
+    "Literal",
+    "TemplateElement",
+    "PrivateIdentifier",
+    "JSXIdentifier",
+    "JSXText",
+];
+/// Content-bearing field names on the node types above.
+const CONTENT_KEYS: &[&str] = &["name", "value", "raw", "cooked", "regex", "bigint"];
+
+/// One occurrence of a structural clone.
+pub struct CloneInstance {
+    pub path: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+/// A set of structurally identical subtrees occurring in 2+ locations.
+pub struct CloneGroup {
+    /// Occurrences, sorted by (path, start_line). Length >= 2.
+    pub instances: Vec<CloneInstance>,
+    /// AST node count of the duplicated subtree.
+    pub node_count: usize,
+    /// True when every occurrence is byte-for-byte structurally identical
+    /// including identifiers/literals (Type 1); false when only the structure
+    /// matches (Type 2, renamed identifiers/literals).
+    pub exact: bool,
+}
+
+pub struct CloneResult {
+    /// Clone groups, sorted by node_count descending then first path ascending.
+    pub groups: Vec<CloneGroup>,
+}
+
+/// A qualifying subtree recorded during the walk.
+struct Candidate {
+    file_idx: usize,
+    canon_blank: String,
+    canon_named: String,
+    node_count: usize,
+    start: usize,
+    end: usize,
+    start_line: usize,
+    end_line: usize,
+}
+
+/// Canonical string pair plus node count produced for a serde_json value.
+struct Rendered {
+    named: String,
+    blank: String,
+    count: usize,
+}
+
+struct WalkCtx<'a> {
+    file_idx: usize,
+    min_nodes: usize,
+    line_starts: &'a [usize],
+    candidates: &'a mut Vec<Candidate>,
+}
+
+/// Detect Type 1/2 structural clones across `files` by bucketing every subtree
+/// of `>= min_nodes` nodes on its identifier-normalized structural key. A group
+/// qualifies only when its largest instance spans `>= min_lines` source lines;
+/// the line span is checked per group (not per instance) so a reformatted or
+/// compacted copy of a clone is not dropped before bucketing. Nested clones
+/// fully contained in a larger clone are pruned so only maximal duplications are
+/// reported.
+pub fn analyze(
+    files: &[PathBuf],
+    src_dir: &Path,
+    min_nodes: usize,
+    min_lines: usize,
+) -> CloneResult {
+    let mut candidates: Vec<Candidate> = Vec::new();
+    let mut paths: Vec<String> = Vec::new();
+
+    for file in files {
+        let Ok(source) = fs::read_to_string(file) else {
+            continue;
+        };
+        let file_idx = paths.len();
+        let allocator = Allocator::default();
+        let source_type = SourceType::from_path(file).unwrap_or_default();
+        let ret = Parser::new(&allocator, &source, source_type).parse();
+        let json = ret.program.to_estree_json(true, false);
+        let Ok(value) = serde_json::from_str::<Value>(&json) else {
+            continue;
+        };
+        let line_starts = line_starts(&source);
+        let mut ctx = WalkCtx {
+            file_idx,
+            min_nodes,
+            line_starts: &line_starts,
+            candidates: &mut candidates,
+        };
+        render(&value, &mut ctx);
+        paths.push(display_path(file, src_dir));
+    }
+
+    let groups_idx = bucket_groups(&candidates);
+    let dominated = nested_dominated(&candidates, &groups_idx);
+    build_result(&candidates, &paths, &groups_idx, &dominated, min_lines)
+}
+
+/// Bucket candidate indices by their structural (blank) key; keep buckets with
+/// 2+ members.
+fn bucket_groups(candidates: &[Candidate]) -> Vec<Vec<usize>> {
+    let mut buckets: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (i, c) in candidates.iter().enumerate() {
+        buckets.entry(&c.canon_blank).or_default().push(i);
+    }
+    let mut groups: Vec<Vec<usize>> = buckets.into_values().filter(|v| v.len() >= 2).collect();
+    // Deterministic group order independent of HashMap iteration.
+    groups.sort_by(|a, b| a[0].cmp(&b[0]));
+    groups
+}
+
+/// Indices of grouped candidates that are positionally contained within a larger
+/// grouped candidate (same file) whose group is at least as large — i.e. clones
+/// explained by an enclosing clone.
+fn nested_dominated(candidates: &[Candidate], groups_idx: &[Vec<usize>]) -> HashSet<usize> {
+    let mut group_size: HashMap<usize, usize> = HashMap::new();
+    for g in groups_idx {
+        for &ci in g {
+            group_size.insert(ci, g.len());
+        }
+    }
+    let grouped: Vec<usize> = {
+        let mut v: Vec<usize> = group_size.keys().copied().collect();
+        v.sort_unstable();
+        v
+    };
+    grouped
+        .iter()
+        .copied()
+        .filter(|&i| {
+            let ci = &candidates[i];
+            let gi = group_size[&i];
+            grouped.iter().any(|&j| {
+                if j == i {
+                    return false;
+                }
+                let cj = &candidates[j];
+                cj.file_idx == ci.file_idx
+                    && cj.start <= ci.start
+                    && ci.end <= cj.end
+                    && cj.node_count > ci.node_count
+                    && group_size[&j] >= gi
+            })
+        })
+        .collect()
+}
+
+fn build_result(
+    candidates: &[Candidate],
+    paths: &[String],
+    groups_idx: &[Vec<usize>],
+    dominated: &HashSet<usize>,
+    min_lines: usize,
+) -> CloneResult {
+    let mut groups: Vec<CloneGroup> = Vec::new();
+    for g in groups_idx {
+        let survivors: Vec<usize> = g
+            .iter()
+            .copied()
+            .filter(|i| !dominated.contains(i))
+            .collect();
+        if survivors.len() < 2 {
+            continue;
+        }
+        // Gate min_lines at the group level on the largest instance: a clone is
+        // reported as long as one copy spans >= min_lines, so a reformatted or
+        // compacted sibling does not suppress it.
+        let max_span = survivors
+            .iter()
+            .map(|&i| candidates[i].end_line - candidates[i].start_line + 1)
+            .max()
+            .unwrap_or(0);
+        if max_span < min_lines {
+            continue;
+        }
+        let first_named = &candidates[survivors[0]].canon_named;
+        let exact = survivors
+            .iter()
+            .all(|&i| &candidates[i].canon_named == first_named);
+        let node_count = candidates[survivors[0]].node_count;
+        let mut instances: Vec<CloneInstance> = survivors
+            .iter()
+            .map(|&i| {
+                let c = &candidates[i];
+                CloneInstance {
+                    path: paths[c.file_idx].clone(),
+                    start_line: c.start_line,
+                    end_line: c.end_line,
+                }
+            })
+            .collect();
+        instances.sort_by(|a, b| {
+            a.path
+                .cmp(&b.path)
+                .then_with(|| a.start_line.cmp(&b.start_line))
+        });
+        groups.push(CloneGroup {
+            instances,
+            node_count,
+            exact,
+        });
+    }
+    groups.sort_by(|a, b| {
+        b.node_count
+            .cmp(&a.node_count)
+            .then_with(|| a.instances[0].path.cmp(&b.instances[0].path))
+            .then_with(|| a.instances[0].start_line.cmp(&b.instances[0].start_line))
+    });
+    CloneResult { groups }
+}
+
+fn render(value: &Value, ctx: &mut WalkCtx) -> Rendered {
+    match value {
+        Value::Object(map) => match map.get("type") {
+            Some(Value::String(ty)) => render_node(map, ty, ctx),
+            _ => render_plain_object(map, ctx),
+        },
+        Value::Array(arr) => {
+            let mut named = String::from("[");
+            let mut blank = String::from("[");
+            let mut count = 0;
+            for el in arr {
+                let r = render(el, ctx);
+                named.push_str(&r.named);
+                named.push(',');
+                blank.push_str(&r.blank);
+                blank.push(',');
+                count += r.count;
+            }
+            named.push(']');
+            blank.push(']');
+            Rendered {
+                named,
+                blank,
+                count,
+            }
+        }
+        other => {
+            let s = other.to_string();
+            Rendered {
+                named: s.clone(),
+                blank: s,
+                count: 0,
+            }
+        }
+    }
+}
+
+fn render_node(map: &Map<String, Value>, ty: &str, ctx: &mut WalkCtx) -> Rendered {
+    let content = CONTENT_TYPES.contains(&ty);
+    let mut keys: Vec<&String> = map
+        .keys()
+        .filter(|k| !matches!(k.as_str(), "type" | "start" | "end" | "range"))
+        .collect();
+    keys.sort();
+
+    let mut named = format!("{ty}(");
+    let mut blank = format!("{ty}(");
+    let mut count = 1usize;
+    for k in keys {
+        let v = &map[k];
+        named.push_str(k);
+        named.push(':');
+        blank.push_str(k);
+        blank.push(':');
+        if content && CONTENT_KEYS.contains(&k.as_str()) {
+            named.push_str(&v.to_string());
+            blank.push('*');
+        } else {
+            let r = render(v, ctx);
+            named.push_str(&r.named);
+            blank.push_str(&r.blank);
+            count += r.count;
+        }
+        named.push(',');
+        blank.push(',');
+    }
+    named.push(')');
+    blank.push(')');
+
+    let start = map.get("start").and_then(Value::as_u64).map_or(0, to_usize);
+    let end = map.get("end").and_then(Value::as_u64).map_or(0, to_usize);
+    let start_line = offset_to_line(ctx.line_starts, start);
+    let end_line = offset_to_line(ctx.line_starts, end);
+    if count >= ctx.min_nodes {
+        ctx.candidates.push(Candidate {
+            file_idx: ctx.file_idx,
+            canon_blank: blank.clone(),
+            canon_named: named.clone(),
+            node_count: count,
+            start,
+            end,
+            start_line,
+            end_line,
+        });
+    }
+    Rendered {
+        named,
+        blank,
+        count,
+    }
+}
+
+/// A `type`-less object (e.g. a regex `{pattern,flags}` payload). Rendered
+/// structurally but never recorded as a clone candidate.
+fn render_plain_object(map: &Map<String, Value>, ctx: &mut WalkCtx) -> Rendered {
+    let mut keys: Vec<&String> = map
+        .keys()
+        .filter(|k| !matches!(k.as_str(), "start" | "end" | "range"))
+        .collect();
+    keys.sort();
+    let mut named = String::from("{");
+    let mut blank = String::from("{");
+    let mut count = 0;
+    for k in keys {
+        let r = render(&map[k], ctx);
+        named.push_str(k);
+        named.push(':');
+        named.push_str(&r.named);
+        named.push(',');
+        blank.push_str(k);
+        blank.push(':');
+        blank.push_str(&r.blank);
+        blank.push(',');
+        count += r.count;
+    }
+    named.push('}');
+    blank.push('}');
+    Rendered {
+        named,
+        blank,
+        count,
+    }
+}
+
+fn to_usize(n: u64) -> usize {
+    usize::try_from(n).unwrap_or(usize::MAX)
+}
+
+/// Byte offsets at which each source line begins (line 1 starts at offset 0).
+fn line_starts(source: &str) -> Vec<usize> {
+    let mut starts = vec![0usize];
+    for (i, b) in source.bytes().enumerate() {
+        if b == b'\n' {
+            starts.push(i + 1);
+        }
+    }
+    starts
+}
+
+/// 1-based line number for a byte offset.
+fn offset_to_line(line_starts: &[usize], offset: usize) -> usize {
+    line_starts.partition_point(|&s| s <= offset).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TempDir;
+
+    /// Write `files` (name, content) under a temp `src` dir and analyze them.
+    fn analyze_files(files: &[(&str, &str)], min_nodes: usize, min_lines: usize) -> CloneResult {
+        let tmp = TempDir::new("clone");
+        let src = tmp.join("src");
+        fs::create_dir_all(&src).unwrap();
+        let paths: Vec<PathBuf> = files
+            .iter()
+            .map(|(name, content)| {
+                let p = src.join(name);
+                fs::write(&p, content).unwrap();
+                p.canonicalize().unwrap()
+            })
+            .collect();
+        let src = src.canonicalize().unwrap();
+        // Leak the temp dir guard for the duration of analysis by keeping it.
+        let result = analyze(&paths, &src, min_nodes, min_lines);
+        drop(tmp);
+        result
+    }
+
+    const FN_A: &str = "export function compute(input: number) {\n  const a = input * 2;\n  const b = a + 1;\n  const c = b - 3;\n  return c;\n}\n";
+    // Same structure as FN_A, renamed identifiers and changed literals (Type 2).
+    const FN_A_RENAMED: &str = "export function evaluate(value: number) {\n  const x = value * 5;\n  const y = x + 9;\n  const z = y - 7;\n  return z;\n}\n";
+
+    // T-601: identical functions in two files form one exact (Type 1) group.
+    #[test]
+    fn detects_type1_exact_clone() {
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", FN_A)], 5, 3);
+        assert_eq!(result.groups.len(), 1);
+        assert!(result.groups[0].exact, "identical copies are Type 1");
+        assert_eq!(result.groups[0].instances.len(), 2);
+    }
+
+    // T-602: renamed identifiers/literals match structurally as a Type 2 group.
+    #[test]
+    fn detects_type2_structural_clone() {
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", FN_A_RENAMED)], 5, 3);
+        assert_eq!(result.groups.len(), 1);
+        assert!(
+            !result.groups[0].exact,
+            "renamed identifiers/literals are Type 2, not exact"
+        );
+        assert_eq!(result.groups[0].instances.len(), 2);
+    }
+
+    // T-603: a duplicate below the node-count threshold is not reported.
+    #[test]
+    fn ignores_clone_below_min_nodes() {
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", FN_A)], 1000, 1);
+        assert!(result.groups.is_empty());
+    }
+
+    // T-604: a duplicate below the line-span threshold is not reported.
+    #[test]
+    fn ignores_clone_below_min_lines() {
+        // FN_A spans 6 lines; require 100 lines -> excluded.
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", FN_A)], 5, 100);
+        assert!(result.groups.is_empty());
+    }
+
+    // T-605: structurally different code yields no groups.
+    #[test]
+    fn no_clone_when_structures_differ() {
+        let other = "export function totally(z: string) {\n  if (z.length > 0) {\n    return z.toUpperCase();\n  }\n  return z;\n}\n";
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", other)], 5, 3);
+        assert!(result.groups.is_empty());
+    }
+
+    // T-606: the same structure across three files is one group of three.
+    #[test]
+    fn counts_multiplicity_across_files() {
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", FN_A), ("c.ts", FN_A)], 5, 3);
+        assert_eq!(result.groups.len(), 1);
+        assert_eq!(result.groups[0].instances.len(), 3);
+    }
+
+    // T-607: a duplicated block nested inside a duplicated function is pruned;
+    // only the maximal (enclosing) clone is reported.
+    #[test]
+    fn prunes_nested_clone() {
+        // The whole function is duplicated, so its inner block is also a
+        // duplicate but fully contained -> a single reported group.
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", FN_A)], 3, 1);
+        assert_eq!(result.groups.len(), 1, "nested block must not double-count");
+    }
+
+    // T-608: groups are ordered by node_count descending.
+    #[test]
+    fn groups_sorted_by_node_count_desc() {
+        let small = "export const f = (p: number) => p + 1 - 2 + 3;\nexport const g = (q: number) => q + 1 - 2 + 3;\n";
+        let big_dup = [("a.ts", FN_A), ("b.ts", FN_A)];
+        let mut files = vec![("c.ts", small)];
+        files.extend_from_slice(&big_dup);
+        let result = analyze_files(&files, 5, 1);
+        assert!(result.groups.len() >= 2);
+        for w in result.groups.windows(2) {
+            assert!(w[0].node_count >= w[1].node_count);
+        }
+    }
+
+    // T-609: instances within a group are ordered by (path, start_line).
+    #[test]
+    fn instances_sorted_by_path() {
+        let result = analyze_files(&[("z.ts", FN_A), ("a.ts", FN_A)], 5, 3);
+        assert_eq!(result.groups.len(), 1);
+        let paths: Vec<&str> = result.groups[0]
+            .instances
+            .iter()
+            .map(|i| i.path.as_str())
+            .collect();
+        assert_eq!(paths, vec!["a.ts", "z.ts"]);
+    }
+
+    // T-610: a syntactically broken file does not panic and does not block
+    // analysis of valid files.
+    #[test]
+    fn tolerates_syntax_error_file() {
+        let broken = "export function ( { { not valid typescript @@@";
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", FN_A), ("c.ts", broken)], 5, 3);
+        assert_eq!(result.groups.len(), 1);
+    }
+
+    // T-611: reported line numbers match the source location of the clone.
+    #[test]
+    fn reports_source_line_numbers() {
+        // Two leading blank lines push the function to start at line 3.
+        let padded = format!("\n\n{FN_A}");
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", &padded)], 5, 3);
+        assert_eq!(result.groups.len(), 1);
+        let b = result.groups[0]
+            .instances
+            .iter()
+            .find(|i| i.path == "b.ts")
+            .unwrap();
+        assert_eq!(
+            b.start_line, 3,
+            "function starts on line 3 after two blanks"
+        );
+    }
+
+    // T-612: a structurally identical clone is still reported when one copy is
+    // compacted below min_lines. min_lines gates the group (max instance span),
+    // not each instance, so a reformatted sibling does not drop the bucket.
+    #[test]
+    fn detects_clone_when_one_copy_is_compacted_below_min_lines() {
+        // FN_A spans 6 lines; the compacted copy spans 3 lines (< min_lines 5).
+        let compacted = "export function compute(input: number) {\n  const a = input * 2; const b = a + 1; const c = b - 3; return c;\n}\n";
+        let result = analyze_files(&[("a.ts", FN_A), ("b.ts", compacted)], 5, 5);
+        assert_eq!(
+            result.groups.len(),
+            1,
+            "the clone survives because one copy spans >= min_lines"
+        );
+        assert_eq!(result.groups[0].instances.len(), 2);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,9 @@ pub enum ConfigSource {
 pub struct GatesConfig {
     pub gates: Option<HashMap<String, bool>>,
     pub coupling_ca_threshold: Option<usize>,
+    pub clone_min_nodes: Option<usize>,
+    pub clone_min_lines: Option<usize>,
+    pub clone_block_threshold: Option<usize>,
     pub source: ConfigSource,
 }
 
@@ -24,6 +27,9 @@ impl Default for GatesConfig {
         Self {
             gates: None,
             coupling_ca_threshold: None,
+            clone_min_nodes: None,
+            clone_min_lines: None,
+            clone_block_threshold: None,
             source: ConfigSource::Default,
         }
     }
@@ -33,12 +39,23 @@ impl Default for GatesConfig {
 struct ToolsJson {
     gates: Option<HashMap<String, serde_json::Value>>,
     coupling: Option<CouplingSection>,
+    clone: Option<CloneSection>,
 }
 
 #[derive(Deserialize)]
 struct CouplingSection {
     #[serde(rename = "caThreshold")]
     ca_threshold: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct CloneSection {
+    #[serde(rename = "minNodes")]
+    min_nodes: Option<usize>,
+    #[serde(rename = "minLines")]
+    min_lines: Option<usize>,
+    #[serde(rename = "blockThreshold")]
+    block_threshold: Option<usize>,
 }
 
 impl GatesConfig {
@@ -67,10 +84,17 @@ impl GatesConfig {
             }
         };
         let coupling_ca_threshold = parsed.coupling.and_then(|c| c.ca_threshold);
+        let (clone_min_nodes, clone_min_lines, clone_block_threshold) =
+            parsed.clone.map_or((None, None, None), |c| {
+                (c.min_nodes, c.min_lines, c.block_threshold)
+            });
         let Some(gates_map) = parsed.gates else {
             return Self {
                 gates: None,
                 coupling_ca_threshold,
+                clone_min_nodes,
+                clone_min_lines,
+                clone_block_threshold,
                 source: ConfigSource::Explicit,
             };
         };
@@ -91,6 +115,9 @@ impl GatesConfig {
         Self {
             gates: Some(gates),
             coupling_ca_threshold,
+            clone_min_nodes,
+            clone_min_lines,
+            clone_block_threshold,
             source: ConfigSource::Explicit,
         }
     }
@@ -208,5 +235,37 @@ mod tests {
         assert!(config.is_enabled("knip"));
         assert!(!config.is_enabled("bad"));
         assert!(!config.is_enabled("num"));
+    }
+
+    // T-511: clone.minNodes/minLines/blockThreshold are read into config.
+    #[test]
+    fn reads_clone_section() {
+        let dir = setup_dir(Some(
+            r#"{"clone":{"minNodes":30,"minLines":8,"blockThreshold":5}}"#,
+        ));
+        let config = GatesConfig::load(&dir);
+        assert_eq!(config.clone_min_nodes, Some(30));
+        assert_eq!(config.clone_min_lines, Some(8));
+        assert_eq!(config.clone_block_threshold, Some(5));
+    }
+
+    // T-512: absent clone section yields no overrides.
+    #[test]
+    fn missing_clone_section_yields_none() {
+        let dir = setup_dir(Some(r#"{"gates":{"knip":true}}"#));
+        let config = GatesConfig::load(&dir);
+        assert_eq!(config.clone_min_nodes, None);
+        assert_eq!(config.clone_min_lines, None);
+        assert_eq!(config.clone_block_threshold, None);
+    }
+
+    // T-513: a partial clone section leaves unspecified fields None.
+    #[test]
+    fn partial_clone_section() {
+        let dir = setup_dir(Some(r#"{"clone":{"minNodes":40}}"#));
+        let config = GatesConfig::load(&dir);
+        assert_eq!(config.clone_min_nodes, Some(40));
+        assert_eq!(config.clone_min_lines, None);
+        assert_eq!(config.clone_block_threshold, None);
     }
 }

--- a/src/depgraph.rs
+++ b/src/depgraph.rs
@@ -73,6 +73,15 @@ pub fn display_path(path: &Path, base: &Path) -> String {
         .to_string()
 }
 
+/// Collect all `.ts`/`.tsx` files under `dir` (canonicalized, excluding
+/// `node_modules`/`.git`/`dist`/`build`/`target`). Shared with the `clone` gate,
+/// which re-parses files independently of the dependency graph.
+pub fn collect_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    collect_source_files(dir, &mut files);
+    files
+}
+
 fn collect_source_files(dir: &Path, files: &mut Vec<PathBuf>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod circular;
+mod clone;
 mod color;
 mod config;
 mod coupling;
@@ -113,12 +114,14 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
     let litmus_enabled = config.is_enabled("litmus");
     let circular_enabled = config.is_enabled("circular");
     let coupling_enabled = config.is_enabled("coupling");
+    let clone_enabled = config.is_enabled("clone");
 
     let total_enabled = enabled.len()
         + script_gates.len()
         + usize::from(litmus_enabled)
         + usize::from(circular_enabled)
-        + usize::from(coupling_enabled);
+        + usize::from(coupling_enabled)
+        + usize::from(clone_enabled);
     if total_enabled == 0 {
         return None;
     }
@@ -147,6 +150,20 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
         let p = project.clone();
         Some(thread::spawn(move || {
             tools::run_graph_gates(&p, circular_enabled, coupling_enabled, ca_threshold)
+        }))
+    } else {
+        None
+    };
+
+    let clone_handle = if clone_enabled {
+        let p = project.clone();
+        let min_nodes = config.clone_min_nodes.unwrap_or(clone::DEFAULT_MIN_NODES);
+        let min_lines = config.clone_min_lines.unwrap_or(clone::DEFAULT_MIN_LINES);
+        let block_threshold = config
+            .clone_block_threshold
+            .unwrap_or(clone::DEFAULT_BLOCK_THRESHOLD);
+        Some(thread::spawn(move || {
+            tools::run_clone(&p, min_nodes, min_lines, block_threshold)
         }))
     } else {
         None
@@ -194,6 +211,16 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
                 if coupling_enabled {
                     results.push(tools::ToolResult::skipped("coupling"));
                 }
+            }
+        }
+    }
+
+    if let Some(h) = clone_handle {
+        match h.join() {
+            Ok(result) => results.push(result),
+            Err(e) => {
+                eprintln!("gates: clone thread panicked: {e:?}");
+                results.push(tools::ToolResult::skipped("clone"));
             }
         }
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,4 +1,5 @@
 use crate::circular;
+use crate::clone;
 use crate::coupling;
 use crate::depgraph;
 use crate::project::ProjectInfo;
@@ -10,7 +11,7 @@ use std::fs;
 use std::io;
 use std::iter;
 use std::os::unix::process::CommandExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
@@ -590,6 +591,77 @@ fn coupling_result(
     )
 }
 
+/// Number of clone groups to list in the failure report before truncating.
+const MAX_REPORTED_GROUPS: usize = 10;
+
+/// Detect Type 1/2 structural clones across the project's `src` tree and block
+/// when the number of clone groups reaches `block_threshold`.
+pub fn run_clone(
+    project: &ProjectInfo,
+    min_nodes: usize,
+    min_lines: usize,
+    block_threshold: usize,
+) -> ToolResult {
+    let src_dir = project.root.join("src");
+    if !project.has_package_json || !src_dir.is_dir() {
+        return ToolResult::skipped("clone");
+    }
+
+    // Declaration files (`*.d.ts`) carry only type shapes, which the gate's
+    // "extract into a shared function" remedy cannot address, so exclude them.
+    let files: Vec<PathBuf> = depgraph::collect_files(&src_dir)
+        .into_iter()
+        .filter(|p| !p.to_string_lossy().ends_with(".d.ts"))
+        .collect();
+    if files.is_empty() {
+        return ToolResult::skipped("clone");
+    }
+
+    let result = clone::analyze(&files, &src_dir, min_nodes, min_lines);
+    if result.groups.len() < block_threshold {
+        return ToolResult::passed("clone");
+    }
+
+    ToolResult::failed(
+        "clone",
+        "Extract the duplicated structures into a shared function or module (DRY).",
+        &clone_report(&result.groups),
+    )
+}
+
+fn clone_report(groups: &[clone::CloneGroup]) -> String {
+    let n = groups.len();
+    let header = format!(
+        "Found {n} structural clone group{}:",
+        if n == 1 { "" } else { "s" }
+    );
+    let mut lines = vec![header];
+    for (i, group) in groups.iter().take(MAX_REPORTED_GROUPS).enumerate() {
+        let kind = if group.exact {
+            "Type 1 (exact)"
+        } else {
+            "Type 2 (structural)"
+        };
+        lines.push(format!(
+            "#{} {} — {} copies, {} nodes",
+            i + 1,
+            kind,
+            group.instances.len(),
+            group.node_count
+        ));
+        for inst in &group.instances {
+            lines.push(format!(
+                "    {}:{}-{}",
+                inst.path, inst.start_line, inst.end_line
+            ));
+        }
+    }
+    if n > MAX_REPORTED_GROUPS {
+        lines.push(format!("... and {} more group(s)", n - MAX_REPORTED_GROUPS));
+    }
+    lines.join("\n")
+}
+
 pub fn run_gate(gate: &GateDefinition, project: &ProjectInfo) -> ToolResult {
     if !(gate.condition)(project) {
         return ToolResult::skipped(gate.name);
@@ -1153,5 +1225,90 @@ test('works', () => {
         let cmd = Command::new("nonexistent-binary-99999");
         let result = run_command("missing", cmd, Duration::from_secs(5));
         assert!(result.is_skipped());
+    }
+
+    fn clone_project(files: &[(&str, &str)]) -> TempDir {
+        let tmp = TempDir::new("clone-gate");
+        fs::write(tmp.join("package.json"), "{}").unwrap();
+        let src = tmp.join("src");
+        fs::create_dir_all(&src).unwrap();
+        for (name, body) in files {
+            fs::write(src.join(name), body).unwrap();
+        }
+        tmp
+    }
+
+    // A duplicated function spanning 6 lines / >20 AST nodes, copied verbatim.
+    const CLONE_BODY: &str = "export function compute(a: number, b: number) {\n  const x = a + b;\n  const y = x * 2;\n  const z = y - 1;\n  const w = z / 3;\n  return w + x;\n}\n";
+
+    // T-621: clone group count reaching block_threshold fails the gate.
+    #[test]
+    fn clone_blocks_at_threshold() {
+        let tmp = clone_project(&[("a.ts", CLONE_BODY), ("b.ts", CLONE_BODY)]);
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: true,
+            has_tsconfig: false,
+        };
+        let result = run_clone(
+            &project,
+            clone::DEFAULT_MIN_NODES,
+            clone::DEFAULT_MIN_LINES,
+            1,
+        );
+        assert!(
+            result.is_failure(),
+            "1 clone group at threshold 1 should fail"
+        );
+        assert!(
+            result.output().contains("structural clone group"),
+            "report should name clone groups: {}",
+            result.output()
+        );
+    }
+
+    // T-622: a clone count below block_threshold passes the gate.
+    #[test]
+    fn clone_passes_below_threshold() {
+        let tmp = clone_project(&[("a.ts", CLONE_BODY), ("b.ts", CLONE_BODY)]);
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: true,
+            has_tsconfig: false,
+        };
+        let result = run_clone(
+            &project,
+            clone::DEFAULT_MIN_NODES,
+            clone::DEFAULT_MIN_LINES,
+            10,
+        );
+        assert!(
+            !result.is_failure(),
+            "clone count under threshold 10 should pass"
+        );
+        assert!(!result.is_skipped());
+    }
+
+    // T-623: declaration files (`*.d.ts`) are excluded from clone analysis, so a
+    // duplicate confined to them does not block. With only `.d.ts` inputs the
+    // gate has nothing to analyze and skips.
+    #[test]
+    fn clone_ignores_declaration_files() {
+        let tmp = clone_project(&[("a.d.ts", CLONE_BODY), ("b.d.ts", CLONE_BODY)]);
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: true,
+            has_tsconfig: false,
+        };
+        let result = run_clone(
+            &project,
+            clone::DEFAULT_MIN_NODES,
+            clone::DEFAULT_MIN_LINES,
+            1,
+        );
+        assert!(
+            result.is_skipped(),
+            "only .d.ts inputs leave nothing to analyze"
+        );
     }
 }


### PR DESCRIPTION
## 概要と背景

`src/` 配下の `.ts/.tsx` から Type 1 (空白正規化一致) / Type 2 (識別子・リテラル差) の構造的クローンを oxc AST の厳密ハッシュで検出する embedded gate を追加する。レビューで見落とされた重複の蓄積を機械的に検出し、DRY 違反が一定数に達した時点でブロックする。

## 変更点

- `src/clone.rs` (新規): ファイル単位で oxc ESTree JSON を後順走査し、`minNodes` 以上の各部分木を識別子ブランク化した正準形でバケット化。2件以上を clone group として Markdown 報告し、group 数が `blockThreshold` (既定3) に達したらブロック
- `src/tools.rs`: `run_clone` gate と Markdown 報告。`*.d.ts` は除外 (型形状のみで「共通関数へ抽出」の remedy が無効なため)
- `src/config.rs`: `clone.minNodes` / `minLines` / `blockThreshold` を読み込み
- `minLines` を group 単位 (最大コピーの span) で判定。整形差のあるコピーで Type 1/2 を取りこぼすバグを防ぐ
- `Cargo.toml`: `oxc_ast` の `serialize` feature 追加のみ (新規依存なし)

## 対象範囲

- **対象外**: Type 3 (間隙あり) と JS/TS 以外。近似マッチは別途 #8 (jscpd) で補完予定

## 設計判断

- 厳密ハッシュ + 多粒度バケットを採用 (曖昧 Jaccard 不採用)。低誤検知でブロック判断に使えることを優先
- coupling/depgraph の oxc AST 基盤を再利用し依存追加ゼロ

## テスト方法

1. `cargo test` → 147 passed
2. `cargo clippy --all-targets` → clean
3. 同一構造の関数を2ファイルに置く → clone group が報告される

## 関連

- Closes #4