### PR TITLE
jscpd 重複コード検知をゲートに追加

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -26,6 +26,14 @@ pub fn bold_green(text: &str) -> String {
     wrap("1;32", text)
 }
 
+pub fn yellow(text: &str) -> String {
+    wrap("33", text)
+}
+
+pub fn bold_yellow(text: &str) -> String {
+    wrap("1;33", text)
+}
+
 pub fn dim(text: &str) -> String {
     wrap("2", text)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,11 @@ pub struct GatesConfig {
     pub clone_min_nodes: Option<usize>,
     pub clone_min_lines: Option<usize>,
     pub clone_block_threshold: Option<usize>,
+    pub jscpd_min_lines: Option<usize>,
+    pub jscpd_min_tokens: Option<usize>,
+    pub jscpd_threshold: Option<f64>,
+    pub jscpd_block: Option<bool>,
+    pub jscpd_ignore: Option<Vec<String>>,
     pub source: ConfigSource,
 }
 
@@ -30,6 +35,11 @@ impl Default for GatesConfig {
             clone_min_nodes: None,
             clone_min_lines: None,
             clone_block_threshold: None,
+            jscpd_min_lines: None,
+            jscpd_min_tokens: None,
+            jscpd_threshold: None,
+            jscpd_block: None,
+            jscpd_ignore: None,
             source: ConfigSource::Default,
         }
     }
@@ -40,6 +50,7 @@ struct ToolsJson {
     gates: Option<HashMap<String, serde_json::Value>>,
     coupling: Option<CouplingSection>,
     clone: Option<CloneSection>,
+    jscpd: Option<JscpdSection>,
 }
 
 #[derive(Deserialize)]
@@ -56,6 +67,17 @@ struct CloneSection {
     min_lines: Option<usize>,
     #[serde(rename = "blockThreshold")]
     block_threshold: Option<usize>,
+}
+
+#[derive(Deserialize)]
+struct JscpdSection {
+    #[serde(rename = "minLines")]
+    min_lines: Option<usize>,
+    #[serde(rename = "minTokens")]
+    min_tokens: Option<usize>,
+    threshold: Option<f64>,
+    block: Option<bool>,
+    ignore: Option<Vec<String>>,
 }
 
 impl GatesConfig {
@@ -88,6 +110,10 @@ impl GatesConfig {
             parsed.clone.map_or((None, None, None), |c| {
                 (c.min_nodes, c.min_lines, c.block_threshold)
             });
+        let (jscpd_min_lines, jscpd_min_tokens, jscpd_threshold, jscpd_block, jscpd_ignore) =
+            parsed.jscpd.map_or((None, None, None, None, None), |j| {
+                (j.min_lines, j.min_tokens, j.threshold, j.block, j.ignore)
+            });
         let Some(gates_map) = parsed.gates else {
             return Self {
                 gates: None,
@@ -95,6 +121,11 @@ impl GatesConfig {
                 clone_min_nodes,
                 clone_min_lines,
                 clone_block_threshold,
+                jscpd_min_lines,
+                jscpd_min_tokens,
+                jscpd_threshold,
+                jscpd_block,
+                jscpd_ignore,
                 source: ConfigSource::Explicit,
             };
         };
@@ -118,6 +149,11 @@ impl GatesConfig {
             clone_min_nodes,
             clone_min_lines,
             clone_block_threshold,
+            jscpd_min_lines,
+            jscpd_min_tokens,
+            jscpd_threshold,
+            jscpd_block,
+            jscpd_ignore,
             source: ConfigSource::Explicit,
         }
     }
@@ -267,5 +303,43 @@ mod tests {
         assert_eq!(config.clone_min_nodes, Some(40));
         assert_eq!(config.clone_min_lines, None);
         assert_eq!(config.clone_block_threshold, None);
+    }
+
+    // T-621: a full jscpd section is read into every field.
+    #[test]
+    fn reads_jscpd_section() {
+        let dir = setup_dir(Some(
+            r#"{"jscpd":{"minLines":8,"minTokens":60,"threshold":15,"block":true,"ignore":["x"]}}"#,
+        ));
+        let config = GatesConfig::load(&dir);
+        assert_eq!(config.jscpd_min_lines, Some(8));
+        assert_eq!(config.jscpd_min_tokens, Some(60));
+        assert_eq!(config.jscpd_threshold, Some(15.0));
+        assert_eq!(config.jscpd_block, Some(true));
+        assert_eq!(config.jscpd_ignore, Some(vec!["x".to_owned()]));
+    }
+
+    // T-622: absent jscpd section yields no overrides.
+    #[test]
+    fn missing_jscpd_section_yields_none() {
+        let dir = setup_dir(Some(r#"{"gates":{"knip":true}}"#));
+        let config = GatesConfig::load(&dir);
+        assert_eq!(config.jscpd_min_lines, None);
+        assert_eq!(config.jscpd_min_tokens, None);
+        assert_eq!(config.jscpd_threshold, None);
+        assert_eq!(config.jscpd_block, None);
+        assert_eq!(config.jscpd_ignore, None);
+    }
+
+    // T-623: a partial jscpd section leaves unspecified fields None.
+    #[test]
+    fn partial_jscpd_section() {
+        let dir = setup_dir(Some(r#"{"jscpd":{"minLines":8}}"#));
+        let config = GatesConfig::load(&dir);
+        assert_eq!(config.jscpd_min_lines, Some(8));
+        assert_eq!(config.jscpd_min_tokens, None);
+        assert_eq!(config.jscpd_threshold, None);
+        assert_eq!(config.jscpd_block, None);
+        assert_eq!(config.jscpd_ignore, None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,13 +115,15 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
     let circular_enabled = config.is_enabled("circular");
     let coupling_enabled = config.is_enabled("coupling");
     let clone_enabled = config.is_enabled("clone");
+    let jscpd_enabled = config.is_enabled("jscpd");
 
     let total_enabled = enabled.len()
         + script_gates.len()
         + usize::from(litmus_enabled)
         + usize::from(circular_enabled)
         + usize::from(coupling_enabled)
-        + usize::from(clone_enabled);
+        + usize::from(clone_enabled)
+        + usize::from(jscpd_enabled);
     if total_enabled == 0 {
         return None;
     }
@@ -164,6 +166,31 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
             .unwrap_or(clone::DEFAULT_BLOCK_THRESHOLD);
         Some(thread::spawn(move || {
             tools::run_clone(&p, min_nodes, min_lines, block_threshold)
+        }))
+    } else {
+        None
+    };
+
+    let jscpd_handle = if jscpd_enabled {
+        let p = project.clone();
+        let min_lines = config
+            .jscpd_min_lines
+            .unwrap_or(tools::DEFAULT_JSCPD_MIN_LINES);
+        let min_tokens = config
+            .jscpd_min_tokens
+            .unwrap_or(tools::DEFAULT_JSCPD_MIN_TOKENS);
+        let threshold = config
+            .jscpd_threshold
+            .unwrap_or(tools::DEFAULT_JSCPD_THRESHOLD);
+        let block = config.jscpd_block.unwrap_or(false);
+        let ignore = config.jscpd_ignore.clone().unwrap_or_else(|| {
+            tools::DEFAULT_JSCPD_IGNORE
+                .iter()
+                .map(|s| (*s).to_owned())
+                .collect()
+        });
+        Some(thread::spawn(move || {
+            tools::run_jscpd(&p, min_lines, min_tokens, threshold, block, &ignore)
         }))
     } else {
         None
@@ -221,6 +248,16 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
             Err(e) => {
                 eprintln!("gates: clone thread panicked: {e:?}");
                 results.push(tools::ToolResult::skipped("clone"));
+            }
+        }
+    }
+
+    if let Some(h) = jscpd_handle {
+        match h.join() {
+            Ok(result) => results.push(result),
+            Err(e) => {
+                eprintln!("gates: jscpd thread panicked: {e:?}");
+                results.push(tools::ToolResult::skipped("jscpd"));
             }
         }
     }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -13,16 +13,17 @@ pub fn format_summary(results: &[ToolResult]) -> String {
     }
 
     let failures: Vec<_> = ran.iter().filter(|r| r.is_failure()).collect();
+    let warnings: Vec<_> = ran.iter().filter(|r| r.is_warning()).collect();
 
     if failures.is_empty() {
-        return format!(
-            "\n{}",
-            color::bold_green(&format!(
-                "Gates \u{2713} {}/{} passed",
-                ran.len(),
-                ran.len()
-            ))
-        );
+        // Warnings are advisory, so they count as ran but not as passed.
+        let passed = ran.len() - warnings.len();
+        let mut lines = vec![
+            String::new(),
+            color::bold_green(&format!("Gates \u{2713} {}/{} passed", passed, ran.len())),
+        ];
+        append_advisories(&mut lines, &warnings);
+        return lines.join("\n");
     }
 
     let mut lines = vec![
@@ -32,21 +33,7 @@ pub fn format_summary(results: &[ToolResult]) -> String {
 
     for f in &failures {
         lines.push(color::red(&format!("  \u{2717} {}", f.name)));
-        let output = f.output();
-        if output.is_empty() {
-            continue;
-        }
-        let non_blank: Vec<&str> = output.lines().filter(|l| !l.trim().is_empty()).collect();
-        let total = non_blank.len();
-        for line in &non_blank[..total.min(MAX_PREVIEW_LINES)] {
-            lines.push(color::red(&format!("    {line}")));
-        }
-        if total > MAX_PREVIEW_LINES {
-            lines.push(color::dim(&format!(
-                "    ... +{} more lines",
-                total - MAX_PREVIEW_LINES
-            )));
-        }
+        push_preview(&mut lines, f.output(), color::red);
     }
 
     lines.push(color::bold_red(FOOTER_SEPARATOR));
@@ -56,7 +43,45 @@ pub fn format_summary(results: &[ToolResult]) -> String {
         if failures.len() == 1 { "" } else { "s" }
     )));
 
+    append_advisories(&mut lines, &warnings);
+
     lines.join("\n")
+}
+
+/// Append a yellow advisory block for warn-level gates. These report duplication
+/// or similar findings without blocking, so they render below any failures.
+fn append_advisories(lines: &mut Vec<String>, warnings: &[&&ToolResult]) {
+    if warnings.is_empty() {
+        return;
+    }
+    lines.push(color::bold_yellow(&format!(
+        "  {} advisory warning{}:",
+        warnings.len(),
+        if warnings.len() == 1 { "" } else { "s" }
+    )));
+    for w in warnings {
+        lines.push(color::yellow(&format!("  \u{26a0} {}", w.name)));
+        push_preview(lines, w.output(), color::yellow);
+    }
+}
+
+/// Push up to `MAX_PREVIEW_LINES` non-blank output lines, colorized, with a dim
+/// truncation note. Shared by failure and advisory rendering.
+fn push_preview(lines: &mut Vec<String>, output: &str, colorize: fn(&str) -> String) {
+    if output.is_empty() {
+        return;
+    }
+    let non_blank: Vec<&str> = output.lines().filter(|l| !l.trim().is_empty()).collect();
+    let total = non_blank.len();
+    for line in &non_blank[..total.min(MAX_PREVIEW_LINES)] {
+        lines.push(colorize(&format!("    {line}")));
+    }
+    if total > MAX_PREVIEW_LINES {
+        lines.push(color::dim(&format!(
+            "    ... +{} more lines",
+            total - MAX_PREVIEW_LINES
+        )));
+    }
 }
 
 #[cfg(test)]
@@ -91,6 +116,14 @@ mod tests {
 
     fn skipped(name: &'static str) -> ToolResult {
         ToolResult::skipped(name)
+    }
+
+    fn warned_with(name: &'static str, output: &str) -> ToolResult {
+        ToolResult {
+            name,
+            hint: "",
+            outcome: GateOutcome::Warned(output.into()),
+        }
     }
 
     #[test]
@@ -189,6 +222,55 @@ mod tests {
         assert!(output.contains("line3"));
         assert!(!output.contains("line4"), "line4 should be truncated");
         assert!(output.contains("+1 more lines"));
+    }
+
+    // T-611: a lone warning shows an advisory line, not a BLOCKED section.
+    #[test]
+    fn warning_only_is_advisory_not_blocked() {
+        let results = vec![warned_with("jscpd", "Found duplication: 12%")];
+        let output = strip_ansi(&format_summary(&results));
+        assert!(!output.contains("BLOCKED"), "warn must not block: {output}");
+        assert!(
+            output.contains("\u{26a0} jscpd"),
+            "missing advisory: {output}"
+        );
+        assert!(output.contains("Found duplication: 12%"), "missing preview");
+    }
+
+    // T-612: a warning counts as ran but not as passed.
+    #[test]
+    fn warning_excluded_from_pass_count() {
+        let results = vec![passed("lint"), warned_with("jscpd", "dup")];
+        let output = strip_ansi(&format_summary(&results));
+        assert!(
+            output.contains("1/2 passed"),
+            "warn excluded from passed: {output}"
+        );
+        assert!(
+            output.contains("advisory"),
+            "missing advisory label: {output}"
+        );
+    }
+
+    // T-613: a failure and a warning together show both BLOCKED and the advisory.
+    #[test]
+    fn failure_and_warning_show_both() {
+        let results = vec![failed("test"), warned_with("jscpd", "dup")];
+        let output = strip_ansi(&format_summary(&results));
+        assert!(output.contains("BLOCKED"), "failure must block: {output}");
+        assert!(
+            output.contains("\u{26a0} jscpd"),
+            "missing advisory: {output}"
+        );
+    }
+
+    // T-614: with no warnings the pass line is unchanged (no advisory text).
+    #[test]
+    fn no_advisory_when_no_warnings() {
+        let results = vec![passed("lint"), passed("test")];
+        let output = strip_ansi(&format_summary(&results));
+        assert!(output.contains("2/2 passed"));
+        assert!(!output.contains("advisory"), "no advisory without warnings");
     }
 
     #[test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -5,6 +5,7 @@ use crate::depgraph;
 use crate::project::ProjectInfo;
 use crate::resolve;
 use crate::sanitize;
+use serde::Deserialize;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
@@ -12,6 +13,7 @@ use std::io;
 use std::iter;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
+use std::process;
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
@@ -25,6 +27,9 @@ pub enum GateOutcome {
     Passed,
     Failed(String),
     Skipped,
+    /// Advisory failure: reported to the human via stderr but not promoted to a
+    /// block decision, so the AI is not forced to act. Used by warn-level gates.
+    Warned(String),
 }
 
 #[derive(Debug)]
@@ -65,8 +70,22 @@ impl ToolResult {
         }
     }
 
+    /// Build a Warned result: the advisory counterpart of `failed`, sharing the
+    /// same truncation policy. Reported to the human but never blocks the AI.
+    pub fn warned(name: &'static str, hint: &'static str, text: &str) -> Self {
+        Self {
+            name,
+            hint,
+            outcome: GateOutcome::Warned(sanitize::tail_lines(text, MAX_OUTPUT_LINES)),
+        }
+    }
+
     pub fn is_failure(&self) -> bool {
         matches!(self.outcome, GateOutcome::Failed(_))
+    }
+
+    pub fn is_warning(&self) -> bool {
+        matches!(self.outcome, GateOutcome::Warned(_))
     }
 
     pub fn is_skipped(&self) -> bool {
@@ -75,7 +94,7 @@ impl ToolResult {
 
     pub fn output(&self) -> &str {
         match &self.outcome {
-            GateOutcome::Failed(s) => s,
+            GateOutcome::Failed(s) | GateOutcome::Warned(s) => s,
             GateOutcome::Passed | GateOutcome::Skipped => "",
         }
     }
@@ -662,6 +681,167 @@ fn clone_report(groups: &[clone::CloneGroup]) -> String {
     lines.join("\n")
 }
 
+pub const DEFAULT_JSCPD_MIN_LINES: usize = 5;
+pub const DEFAULT_JSCPD_MIN_TOKENS: usize = 50;
+pub const DEFAULT_JSCPD_THRESHOLD: f64 = 10.0;
+
+/// Default ignore globs: dependencies, plus test/spec files and generated/build
+/// output, which the gate's "extract shared code" remedy does not apply to.
+/// `node_modules` is normally excluded by jscpd's gitignore handling, but is
+/// listed here so a repo that does not gitignore it still skips the scan (which
+/// would otherwise blow the gate's timeout). jscpd's own docs use this glob.
+pub const DEFAULT_JSCPD_IGNORE: &[&str] = &[
+    "**/node_modules/**",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/generated/**",
+    "**/dist/**",
+];
+
+const JSCPD_HINT: &str = "Extract the duplicated code into a shared function or module (DRY).";
+
+/// Subset of jscpd's JSON report the gate reads. `duplicates` and its inner
+/// fields default so a shape change in the (prose-documented) duplicate entries
+/// degrades the file-pair listing rather than failing the parse and silently
+/// skipping the gate; the load-bearing `percentage` stays required.
+#[derive(Deserialize)]
+pub struct JscpdReport {
+    statistics: JscpdStatistics,
+    #[serde(default)]
+    duplicates: Vec<JscpdDuplicate>,
+}
+
+#[derive(Deserialize)]
+struct JscpdStatistics {
+    total: JscpdTotal,
+}
+
+#[derive(Deserialize)]
+struct JscpdTotal {
+    percentage: f64,
+}
+
+#[derive(Deserialize)]
+struct JscpdDuplicate {
+    #[serde(default)]
+    lines: usize,
+    #[serde(rename = "firstFile", default)]
+    first_file: JscpdFile,
+    #[serde(rename = "secondFile", default)]
+    second_file: JscpdFile,
+}
+
+#[derive(Deserialize, Default)]
+struct JscpdFile {
+    #[serde(default)]
+    name: String,
+}
+
+fn parse_jscpd_report(json: &str) -> Option<JscpdReport> {
+    serde_json::from_str(json).ok()
+}
+
+/// Map a parsed report to an outcome. Duplication at or below `threshold`
+/// passes; above it warns (advisory) or, when `block` is set, fails (blocks).
+fn jscpd_outcome(report: &JscpdReport, threshold: f64, block: bool) -> ToolResult {
+    if report.statistics.total.percentage <= threshold {
+        return ToolResult::passed("jscpd");
+    }
+    let text = jscpd_report(report, threshold);
+    if block {
+        ToolResult::failed("jscpd", JSCPD_HINT, &text)
+    } else {
+        ToolResult::warned("jscpd", JSCPD_HINT, &text)
+    }
+}
+
+fn jscpd_report(report: &JscpdReport, threshold: f64) -> String {
+    let pct = report.statistics.total.percentage;
+    let mut lines = vec![format!(
+        "Found duplication: {pct}% (threshold {threshold}%)"
+    )];
+    for dup in report.duplicates.iter().take(MAX_REPORTED_GROUPS) {
+        lines.push(format!(
+            "    {} \u{2194} {} ({} lines)",
+            dup.first_file.name, dup.second_file.name, dup.lines
+        ));
+    }
+    let n = report.duplicates.len();
+    if n > MAX_REPORTED_GROUPS {
+        lines.push(format!(
+            "    ... and {} more pair(s)",
+            n - MAX_REPORTED_GROUPS
+        ));
+    }
+    lines.join("\n")
+}
+
+/// Run jscpd (token-based Type 3 clone detection) over the project. jscpd writes
+/// its JSON to a file, not stdout, so the report is directed to a temp dir and
+/// read back. Fail-open: a missing binary, timeout, or unreadable/unparseable
+/// report all skip rather than block.
+pub fn run_jscpd(
+    project: &ProjectInfo,
+    min_lines: usize,
+    min_tokens: usize,
+    threshold: f64,
+    block: bool,
+    ignore: &[String],
+) -> ToolResult {
+    if !project.has_package_json {
+        return ToolResult::skipped("jscpd");
+    }
+
+    let out_dir = env::temp_dir().join(format!("gates-jscpd-{}", process::id()));
+    // Clear any report left by a prior run whose cleanup failed before this PID
+    // was reused, so a stale report is never read as the current run's result.
+    let _ = fs::remove_dir_all(&out_dir);
+    if let Err(e) = fs::create_dir_all(&out_dir) {
+        eprintln!("gates: jscpd temp dir create failed: {e}");
+        return ToolResult::skipped("jscpd");
+    }
+
+    let bin = resolve::resolve_bin("jscpd", &project.root);
+    let mut cmd = Command::new(&bin);
+    cmd.arg(&project.root)
+        .args(["--reporters", "json"])
+        .arg("--output")
+        .arg(&out_dir)
+        .arg("--silent")
+        .args(["--min-lines", &min_lines.to_string()])
+        .args(["--min-tokens", &min_tokens.to_string()]);
+    if !ignore.is_empty() {
+        cmd.args(["--ignore", &ignore.join(",")]);
+    }
+    cmd.current_dir(&project.root);
+
+    let result = run_command("jscpd", cmd, GATE_TIMEOUT);
+    let outcome = if result.is_skipped() {
+        // Binary missing or timed out: fail-open.
+        result
+    } else {
+        let report_path = out_dir.join("jscpd-report.json");
+        match fs::read_to_string(&report_path) {
+            Ok(json) => match parse_jscpd_report(&json) {
+                Some(report) => jscpd_outcome(&report, threshold, block),
+                None => {
+                    eprintln!("gates: jscpd report parse failed");
+                    ToolResult::skipped("jscpd")
+                }
+            },
+            Err(e) => {
+                eprintln!("gates: jscpd report read failed: {e}");
+                ToolResult::skipped("jscpd")
+            }
+        }
+    };
+
+    if let Err(e) = fs::remove_dir_all(&out_dir) {
+        eprintln!("gates: jscpd temp dir cleanup failed: {e}");
+    }
+    outcome
+}
+
 pub fn run_gate(gate: &GateDefinition, project: &ProjectInfo) -> ToolResult {
     if !(gate.condition)(project) {
         return ToolResult::skipped(gate.name);
@@ -681,6 +861,12 @@ mod tests {
     use crate::test_utils::TempDir;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::{Mutex, PoisonError};
+
+    /// run_jscpd derives its temp output dir from the process PID, so the three
+    /// end-to-end tests below share one dir. Serialize them so one test's report
+    /// is never read (or wiped) by another running concurrently.
+    static JSCPD_RUN_LOCK: Mutex<()> = Mutex::new(());
 
     fn test_project(has_pkg: bool, has_ts: bool) -> ProjectInfo {
         ProjectInfo {
@@ -848,6 +1034,28 @@ mod tests {
         assert!(r.is_skipped());
         assert!(!r.is_failure());
         assert!(r.output().is_empty());
+    }
+
+    // T-601: a Warned outcome is not a failure (stays out of the block decision).
+    #[test]
+    fn warned_is_not_failure() {
+        let r = ToolResult::warned("jscpd", "hint", "dup");
+        assert!(!r.is_failure());
+    }
+
+    // T-602: a Warned outcome counts as ran, not skipped.
+    #[test]
+    fn warned_is_not_skipped() {
+        let r = ToolResult::warned("jscpd", "hint", "dup");
+        assert!(!r.is_skipped());
+        assert!(r.is_warning());
+    }
+
+    // T-603: a Warned outcome exposes its text via output().
+    #[test]
+    fn warned_exposes_output() {
+        let r = ToolResult::warned("jscpd", "hint", "duplication detail");
+        assert_eq!(r.output(), "duplication detail");
     }
 
     #[test]
@@ -1309,6 +1517,153 @@ test('works', () => {
         assert!(
             result.is_skipped(),
             "only .d.ts inputs leave nothing to analyze"
+        );
+    }
+
+    fn jscpd_json(percentage: f64, duplicates: &str) -> String {
+        format!(
+            r#"{{"statistics":{{"total":{{"percentage":{percentage}}}}},"duplicates":[{duplicates}]}}"#
+        )
+    }
+
+    // T-631: duplication above threshold without block set → Warned (advisory).
+    #[test]
+    fn jscpd_warns_above_threshold_without_block() {
+        let report = parse_jscpd_report(&jscpd_json(12.0, "")).unwrap();
+        let result = jscpd_outcome(&report, 10.0, false);
+        assert!(result.is_warning());
+        assert!(!result.is_failure());
+    }
+
+    // T-632: duplication above threshold with block set → Failed (blocks).
+    #[test]
+    fn jscpd_fails_above_threshold_with_block() {
+        let report = parse_jscpd_report(&jscpd_json(12.0, "")).unwrap();
+        let result = jscpd_outcome(&report, 10.0, true);
+        assert!(result.is_failure());
+        assert!(!result.is_warning());
+    }
+
+    // T-633: duplication below threshold → Passed.
+    #[test]
+    fn jscpd_passes_below_threshold() {
+        let report = parse_jscpd_report(&jscpd_json(8.0, "")).unwrap();
+        let result = jscpd_outcome(&report, 10.0, false);
+        assert!(!result.is_failure());
+        assert!(!result.is_warning());
+        assert!(!result.is_skipped());
+    }
+
+    // T-634: duplication exactly at threshold → Passed (comparison is `>`, not `>=`).
+    #[test]
+    fn jscpd_passes_at_threshold_boundary() {
+        let report = parse_jscpd_report(&jscpd_json(10.0, "")).unwrap();
+        let result = jscpd_outcome(&report, 10.0, false);
+        assert!(!result.is_warning());
+        assert!(!result.is_failure());
+    }
+
+    // T-635: malformed JSON yields None rather than panicking.
+    #[test]
+    fn jscpd_parse_rejects_invalid_json() {
+        assert!(parse_jscpd_report("not json{{{").is_none());
+    }
+
+    // T-636: the report lists each duplicate file pair with its line span.
+    #[test]
+    fn jscpd_report_lists_file_pairs() {
+        let dup = r#"{"lines":7,"firstFile":{"name":"src/a.ts"},"secondFile":{"name":"src/b.ts"}}"#;
+        let report = parse_jscpd_report(&jscpd_json(12.0, dup)).unwrap();
+        let result = jscpd_outcome(&report, 10.0, false);
+        let output = result.output();
+        assert!(output.contains("12%"), "header percentage: {output}");
+        assert!(output.contains("src/a.ts"), "first file: {output}");
+        assert!(output.contains("src/b.ts"), "second file: {output}");
+        assert!(output.contains("7 lines"), "line span: {output}");
+    }
+
+    // T-637: jscpd skips a project without package.json (fail-open).
+    #[test]
+    fn jscpd_skips_without_package_json() {
+        let project = test_project(false, false);
+        let result = run_jscpd(&project, 5, 50, 10.0, false, &[]);
+        assert!(result.is_skipped());
+    }
+
+    /// Install a fake `jscpd` binary that writes `report_body` (when non-empty)
+    /// to the `--output` dir, mirroring how the real jscpd emits its JSON file.
+    fn jscpd_project_with_fake_bin(report_body: &str) -> (TempDir, ProjectInfo) {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new("jscpd-gate");
+        fs::write(tmp.join("package.json"), "{}").unwrap();
+        let bin_dir = tmp.join("node_modules/.bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let bin = bin_dir.join("jscpd");
+        let script = if report_body.is_empty() {
+            "#!/bin/sh\nexit 0\n".to_owned()
+        } else {
+            format!(
+                "#!/bin/sh\nout=\"\"\nwhile [ $# -gt 0 ]; do\n  if [ \"$1\" = \"--output\" ]; then out=\"$2\"; fi\n  shift\ndone\nmkdir -p \"$out\"\ncat > \"$out/jscpd-report.json\" <<'EOF'\n{report_body}\nEOF\n"
+            )
+        };
+        fs::write(&bin, script).unwrap();
+        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: true,
+            has_tsconfig: false,
+        };
+        (tmp, project)
+    }
+
+    // T-638: end-to-end — jscpd writes a report above threshold, gate warns.
+    #[test]
+    fn jscpd_warns_from_written_report() {
+        let _guard = JSCPD_RUN_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let body = r#"{"statistics":{"total":{"percentage":25.0}},"duplicates":[{"lines":7,"firstFile":{"name":"a.ts"},"secondFile":{"name":"b.ts"}}]}"#;
+        let (_tmp, project) = jscpd_project_with_fake_bin(body);
+        let result = run_jscpd(&project, 5, 50, 10.0, false, &[]);
+        assert!(result.is_warning(), "25% over threshold 10 should warn");
+        assert!(result.output().contains("a.ts"));
+    }
+
+    // T-639: a binary that writes no report file skips (fail-open).
+    #[test]
+    fn jscpd_skips_when_report_missing() {
+        let _guard = JSCPD_RUN_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let (_tmp, project) = jscpd_project_with_fake_bin("");
+        let result = run_jscpd(&project, 5, 50, 10.0, false, &[]);
+        assert!(result.is_skipped(), "missing report should skip, not block");
+    }
+
+    // T-640: a stale report left in the temp dir (prior run's cleanup failed,
+    // then PID reused) is not read as the current run's result. run_jscpd must
+    // start from a clean output dir.
+    #[test]
+    fn jscpd_ignores_stale_report_from_prior_run() {
+        let _guard = JSCPD_RUN_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let out_dir = env::temp_dir().join(format!("gates-jscpd-{}", process::id()));
+        fs::create_dir_all(&out_dir).unwrap();
+        fs::write(
+            out_dir.join("jscpd-report.json"),
+            r#"{"statistics":{"total":{"percentage":99.0}},"duplicates":[]}"#,
+        )
+        .unwrap();
+
+        // The current run's binary writes no report (finds nothing / fails to emit).
+        let (_tmp, project) = jscpd_project_with_fake_bin("");
+        let result = run_jscpd(&project, 5, 50, 10.0, false, &[]);
+
+        assert!(
+            result.is_skipped(),
+            "stale report must not be read as the current run: {}",
+            result.output()
         );
     }
 }


### PR DESCRIPTION
## 概要と背景

PostToolUse ゲートに jscpd(Copy-Paste Detector)を追加し、編集のたびにプロジェクトの重複コード率を測る。既存の埋め込み oxc clone ゲート(#4)が構造ハッシュで拾えない、外部ツール基準のコピペ重複を warn レベルで可視化する。

## 変更点

- jscpd ゲート本体(src/tools.rs): JSON report の `statistics.total.percentage` を threshold(既定10)と自前比較。exit code 非依存
- warn レベル新設(GateOutcome::Warned): 既定は stderr advisory のみでブロックしない。config `jscpd.block:true` で Failed に昇格
- reporter(src/reporter.rs): warn を failure と分離し advisory セクションに表示、passed 数から除外
- config(src/config.rs): `minLines`/`minTokens`/`threshold`/`block`/`ignore` を読む
- fail-open: binary 不在 / spawn 失敗 / timeout / report 不在 / parse 失敗 / package.json 不在 は全て Skipped

## 対象範囲

- **非対象**: oxc clone ゲート(#4)との二重報告は warn-only のため二重ブロックにならず advisory ノイズに留める(issue 著者承認済み)

## 設計判断

- 判定を jscpd の exit code でなく JSON percentage の自前比較にし、threshold と exit code の矛盾を解消
- `jscpd.ignore` 指定時は既定(node_modules/test/spec/generated/dist)を置換。lint ツール慣習に合わせ、warn レベルで安全
- node_modules を既定 ignore に追加。gitignore 既定 on で通常 repo は除外されるが、gitignore しない repo の timeout を防ぐ保険(jscpd docs の例に準拠)

## テスト方法

1. `cargo test --bin gates` → 169 tests pass(jscpd 統合テストは fake bin で network 不要)
2. real jscpd contract 検証: 44.44%% 重複 fixture に gates と同フラグで `npx jscpd` を実行 → report path / percentage scale(0-100)/ firstFile/secondFile/lines 形状 / `--ignore` CSV が parser と一致

## 関連

- Closes #8

https://claude.ai/code/session_019vBKgPPT9rh5sf6D5Wog9j