### PR TITLE
feat: 永続監査ログと show サブコマンドの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,32 @@ No output means all gates passed. On failure, block JSON is printed to stdout:
 { "decision": "block", "reason": "lint failed. Fix lint errors.\n\nerror output..." }
 ```
 
+### Audit Log
+
+Every run appends its pass/fail decision to `$XDG_DATA_HOME/gates/audit.jsonl` (default `~/.local/share/gates/audit.jsonl`) as one JSON object per line. The write is fail-open, so a logging failure never blocks the agent.
+
+```jsonl
+{"ts":"2026-04-11T11:00:00Z","project":"/Users/me/foo","decision":"fail","failed":["lint","test"]}
+{"ts":"2026-04-11T11:05:30Z","project":"/Users/me/foo","decision":"pass","failed":[]}
+```
+
+| Field      | Type    | Description                         |
+| ---------- | ------- | ----------------------------------- |
+| `ts`       | RFC3339 | Event time in UTC                   |
+| `project`  | string  | Absolute project directory          |
+| `decision` | string  | `pass` or `fail`                    |
+| `failed`   | array   | Failed gate names (empty on a pass) |
+
+Review history with the `show` subcommand:
+
+```bash
+gates show                      # last 20 entries
+gates show --last 50            # last 50 entries
+gates show --decision fail      # only failures, then last 20 of those
+```
+
+It prints an aligned table of `TIMESTAMP  DECISION  PROJECT  FAILED_GATES`. With no log file yet, it prints nothing.
+
 ## Configuration
 
 Add a `gates` key to `.claude/tools.json` in your project root.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,315 @@
+//! Persistent audit log: appends every pass/fail decision to a JSONL file and
+//! reads it back for the `show` subcommand. Writes are fail-open — a failure to
+//! record never breaks the hook (OUTCOME constraint: nothing blocks the agent).
+
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const LOG_FILE: &str = "audit.jsonl";
+
+/// One audit record. `failed` is empty on a pass decision.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AuditEntry {
+    pub ts: String,
+    pub project: String,
+    pub decision: String,
+    pub failed: Vec<String>,
+}
+
+/// Resolve the audit directory from `$XDG_DATA_HOME/gates`, falling back to
+/// `$HOME/.local/share/gates`. Returns None when neither is set (write skipped).
+pub fn default_dir() -> Option<PathBuf> {
+    if let Some(xdg) = env::var_os("XDG_DATA_HOME").filter(|s| !s.is_empty()) {
+        return Some(Path::new(&xdg).join("gates"));
+    }
+    env::var_os("HOME")
+        .filter(|s| !s.is_empty())
+        .map(|home| Path::new(&home).join(".local/share/gates"))
+}
+
+/// Append one entry as a JSONL line. Creates the directory and file as needed.
+/// Returns Err on any IO/serialization failure; the caller must not propagate it
+/// into the hook control flow.
+pub fn append(dir: &Path, entry: &AuditEntry) -> io::Result<()> {
+    fs::create_dir_all(dir)?;
+    let mut line = serde_json::to_string(entry)?;
+    line.push('\n');
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join(LOG_FILE))?;
+    // One write_all, not writeln!: writeln! emits the body and the newline as
+    // separate write() syscalls, so under O_APPEND two concurrent hook processes
+    // can interleave into a torn JSONL line. A single write of the line+newline
+    // keeps each record atomic (within PIPE_BUF).
+    file.write_all(line.as_bytes())
+}
+
+/// Read entries, optionally filter by decision, then keep the last `last` of the
+/// matched set. A missing log file is normal (nothing recorded yet) → empty Vec.
+pub fn query(dir: &Path, last: usize, decision: Option<&str>) -> Vec<AuditEntry> {
+    let content = match fs::read_to_string(dir.join(LOG_FILE)) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let mut entries: Vec<AuditEntry> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<AuditEntry>(l).ok())
+        .filter(|e| decision.is_none_or(|d| e.decision == d))
+        .collect();
+    if entries.len() > last {
+        entries = entries.split_off(entries.len() - last);
+    }
+    entries
+}
+
+/// Render entries as an aligned table: `TIMESTAMP  DECISION  PROJECT  FAILED_GATES`.
+pub fn render(entries: &[AuditEntry]) -> String {
+    let header = ["TIMESTAMP", "DECISION", "PROJECT", "FAILED_GATES"];
+    let mut rows: Vec<[String; 4]> = vec![header.map(str::to_owned)];
+    for e in entries {
+        let failed = if e.failed.is_empty() {
+            "-".to_owned()
+        } else {
+            e.failed.join(",")
+        };
+        rows.push([e.ts.clone(), e.decision.clone(), e.project.clone(), failed]);
+    }
+
+    // The last column needs no padding, so width it across the first three only.
+    // Count chars, not bytes: `{:<w$}` pads by char count, so a byte-length width
+    // would misalign columns for non-ASCII project paths.
+    let mut widths = [0usize; 3];
+    for row in &rows {
+        for (i, w) in widths.iter_mut().enumerate() {
+            *w = (*w).max(row[i].chars().count());
+        }
+    }
+
+    rows.iter()
+        .map(|row| {
+            format!(
+                "{:<w0$}  {:<w1$}  {:<w2$}  {}",
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                w0 = widths[0],
+                w1 = widths[1],
+                w2 = widths[2],
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Current UTC time as an RFC3339 string (`YYYY-MM-DDThh:mm:ssZ`).
+pub fn now_rfc3339() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format_rfc3339(secs)
+}
+
+/// Format epoch seconds as an RFC3339 UTC string. Date split uses Howard
+/// Hinnant's `civil_from_days` algorithm (chrono-free, no startup cost).
+fn format_rfc3339(epoch_secs: u64) -> String {
+    let days = i64::try_from(epoch_secs / 86_400).unwrap_or(0);
+    let sod = epoch_secs % 86_400;
+    let (year, month, day) = civil_from_days(days);
+    let (hour, min, sec) = (sod / 3600, (sod % 3600) / 60, sod % 60);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z")
+}
+
+/// Convert days since 1970-01-01 to (year, month [1-12], day [1-31]).
+/// <https://howardhinnant.github.io/date_algorithms.html#civil_from_days>
+// m ∈ [1,12], d ∈ [1,31] by construction, so neither u32 cast can truncate.
+#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let year = if m <= 2 { y + 1 } else { y };
+    (year, m as u32, d as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TempDir;
+
+    fn entry(ts: &str, decision: &str, failed: &[&str]) -> AuditEntry {
+        AuditEntry {
+            ts: ts.to_owned(),
+            project: "/p".to_owned(),
+            decision: decision.to_owned(),
+            failed: failed.iter().map(|s| (*s).to_owned()).collect(),
+        }
+    }
+
+    #[test]
+    fn formats_unix_epoch_zero() {
+        assert_eq!(format_rfc3339(0), "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn formats_known_epoch() {
+        // 1700000000 == 2023-11-14T22:13:20Z
+        assert_eq!(format_rfc3339(1_700_000_000), "2023-11-14T22:13:20Z");
+    }
+
+    #[test]
+    fn formats_leap_day() {
+        // 1709164800 == 2024-02-29T00:00:00Z (leap day); +86400 == 2024-03-01
+        assert_eq!(format_rfc3339(1_709_164_800), "2024-02-29T00:00:00Z");
+        assert_eq!(format_rfc3339(1_709_251_200), "2024-03-01T00:00:00Z");
+    }
+
+    #[test]
+    fn append_then_query_round_trips() {
+        let tmp = TempDir::new("audit-rt");
+        let e = entry("2026-04-11T11:00:00Z", "fail", &["lint", "test"]);
+        append(&tmp, &e).unwrap();
+        let got = query(&tmp, 20, None);
+        assert_eq!(got, vec![e]);
+    }
+
+    #[test]
+    fn append_creates_missing_directory() {
+        let tmp = TempDir::new("audit-mkdir");
+        let nested = tmp.join("a/b/c");
+        append(&nested, &entry("t", "pass", &[])).unwrap();
+        assert_eq!(query(&nested, 20, None).len(), 1);
+    }
+
+    #[test]
+    fn query_missing_file_returns_empty() {
+        let tmp = TempDir::new("audit-missing");
+        assert!(query(&tmp, 20, None).is_empty());
+    }
+
+    #[test]
+    fn query_filters_by_decision() {
+        let tmp = TempDir::new("audit-filter");
+        append(&tmp, &entry("t1", "pass", &[])).unwrap();
+        append(&tmp, &entry("t2", "fail", &["lint"])).unwrap();
+        append(&tmp, &entry("t3", "pass", &[])).unwrap();
+
+        let fails = query(&tmp, 20, Some("fail"));
+        assert_eq!(fails.len(), 1);
+        assert_eq!(fails[0].ts, "t2");
+
+        assert_eq!(query(&tmp, 20, Some("pass")).len(), 2);
+    }
+
+    #[test]
+    fn query_keeps_last_n_of_matched_set() {
+        let tmp = TempDir::new("audit-lastn");
+        for i in 0..5 {
+            append(&tmp, &entry(&format!("t{i}"), "pass", &[])).unwrap();
+        }
+        let got = query(&tmp, 2, None);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].ts, "t3");
+        assert_eq!(got[1].ts, "t4");
+    }
+
+    #[test]
+    fn concurrent_appends_do_not_tear_lines() {
+        // Each record must reach the file as one atomic write so parallel hook
+        // processes never interleave into a torn JSONL line. Drive it with many
+        // threads appending to the same dir, then assert every entry survives.
+        use std::sync::Arc;
+        use std::thread;
+
+        let tmp = Arc::new(TempDir::new("audit-concurrent"));
+        let threads = 8;
+        let per_thread = 25;
+        let handles: Vec<_> = (0..threads)
+            .map(|t| {
+                let dir = Arc::clone(&tmp);
+                thread::spawn(move || {
+                    for i in 0..per_thread {
+                        let e = entry(&format!("t{t}-{i}"), "fail", &["lint", "test"]);
+                        append(&dir, &e).unwrap();
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let got = query(&tmp, usize::MAX, None);
+        assert_eq!(got.len(), threads * per_thread);
+    }
+
+    #[test]
+    fn query_skips_corrupt_lines() {
+        let tmp = TempDir::new("audit-corrupt");
+        append(&tmp, &entry("t1", "pass", &[])).unwrap();
+        // Append a non-JSON line directly.
+        let mut f = fs::OpenOptions::new()
+            .append(true)
+            .open(tmp.join(LOG_FILE))
+            .unwrap();
+        writeln!(f, "not json{{").unwrap();
+        append(&tmp, &entry("t2", "fail", &["x"])).unwrap();
+
+        let got = query(&tmp, 20, None);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].ts, "t1");
+        assert_eq!(got[1].ts, "t2");
+    }
+
+    #[test]
+    fn renders_table_with_header_and_failed_dash() {
+        let out = render(&[
+            entry("2026-04-11T11:00:00Z", "fail", &["lint", "test"]),
+            entry("2026-04-11T11:05:30Z", "pass", &[]),
+        ]);
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines[0].starts_with("TIMESTAMP"));
+        assert!(lines[0].contains("FAILED_GATES"));
+        assert!(lines[1].contains("fail"));
+        assert!(lines[1].contains("lint,test"));
+        assert!(lines[2].trim_end().ends_with('-'));
+    }
+
+    #[test]
+    fn renders_align_columns_by_char_count_for_non_ascii() {
+        let mut a = entry("2026-04-11T11:00:00Z", "pass", &[]);
+        a.project = "/プロジェクト".to_owned(); // non-ASCII path
+        let mut b = entry("2026-04-11T11:05:30Z", "pass", &[]);
+        b.project = "/p".to_owned();
+        let out = render(&[a, b]);
+        // The FAILED_GATES column starts at the same char offset on every line.
+        let offsets: Vec<usize> = out
+            .lines()
+            .map(|l| l.chars().count() - l.chars().rev().take_while(|c| *c != ' ').count())
+            .collect();
+        assert!(
+            offsets.windows(2).all(|w| w[0] == w[1]),
+            "columns misaligned: {offsets:?}"
+        );
+    }
+
+    #[test]
+    fn renders_empty_entries_as_header_only() {
+        let out = render(&[]);
+        assert_eq!(out.lines().count(), 1);
+        assert!(out.starts_with("TIMESTAMP"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod audit;
 mod circular;
 mod clone;
 mod color;
@@ -288,6 +289,8 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
         return None;
     }
 
+    record_audit(project_dir, &failures, overrides);
+
     if !failures.is_empty() {
         let reason = build_fix_prompt(&format_failures(&failures));
         let block = serde_json::json!({
@@ -298,6 +301,30 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
     }
 
     None
+}
+
+/// Append the pass/fail decision to the audit log. Fail-open: any error is
+/// reported to stderr but never propagated into the hook control flow.
+fn record_audit(
+    project_dir: &Path,
+    failures: &[&tools::ToolResult],
+    overrides: &tools::EnvOverrides,
+) {
+    let Some(dir) = overrides.audit_dir.as_deref() else {
+        return;
+    };
+    let project = project_dir
+        .canonicalize()
+        .unwrap_or_else(|_| project_dir.to_path_buf());
+    let entry = audit::AuditEntry {
+        ts: audit::now_rfc3339(),
+        project: project.to_string_lossy().into_owned(),
+        decision: if failures.is_empty() { "pass" } else { "fail" }.to_owned(),
+        failed: failures.iter().map(|f| f.name.to_owned()).collect(),
+    };
+    if let Err(e) = audit::append(dir, &entry) {
+        eprintln!("gates: audit log write failed: {e}");
+    }
 }
 
 fn warn_missing_tools(results: &[tools::ToolResult], project: &project::ProjectInfo) {
@@ -322,8 +349,64 @@ fn warn_missing_tools(results: &[tools::ToolResult], project: &project::ProjectI
     }
 }
 
+const SHOW_USAGE: &str = "usage: gates show [--last N] [--decision pass|fail]";
+
+/// Parsed `show` options. `None` decision means no filter.
+struct ShowArgs {
+    last: usize,
+    decision: Option<String>,
+}
+
+fn parse_show_args(args: &[String]) -> Result<ShowArgs, String> {
+    let mut last = 20;
+    let mut decision = None;
+    let mut it = args.iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--last" => {
+                let v = it.next().ok_or("--last requires a value")?;
+                last = v
+                    .parse()
+                    .map_err(|_| format!("invalid --last value: {v}"))?;
+            }
+            "--decision" => {
+                let v = it.next().ok_or("--decision requires a value")?;
+                if v != "pass" && v != "fail" {
+                    return Err(format!("--decision must be pass or fail, got: {v}"));
+                }
+                decision = Some(v.clone());
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    Ok(ShowArgs { last, decision })
+}
+
+fn run_show(args: &[String]) -> i32 {
+    let parsed = match parse_show_args(args) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("gates: {e}\n{SHOW_USAGE}");
+            return 1;
+        }
+    };
+    let Some(dir) = audit::default_dir() else {
+        return 0;
+    };
+    let entries = audit::query(&dir, parsed.last, parsed.decision.as_deref());
+    if !entries.is_empty() {
+        println!("{}", audit::render(&entries));
+    }
+    0
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
+
+    if args.get(1).map(String::as_str) == Some("show") {
+        process::exit(run_show(&args[2..]));
+    }
+
     if args.len() > 2 {
         eprintln!("usage: gates [project_dir]");
         process::exit(1);
@@ -601,11 +684,131 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(&fake_knip, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let result = run(&tmp);
+        let audit_dir = tmp.join("audit");
+        let result = run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                audit_dir: Some(audit_dir.clone()),
+                ..Default::default()
+            },
+        );
         assert!(result.is_some());
         let json: serde_json::Value = serde_json::from_str(&result.unwrap()).unwrap();
         assert_eq!(json["decision"], "block");
         assert!(json["reason"].as_str().unwrap().contains("\u{2717} knip"));
+
+        // The failure is recorded once with decision=fail and the failed gate.
+        let logged = audit::query(&audit_dir, 20, None);
+        assert_eq!(logged.len(), 1);
+        assert_eq!(logged[0].decision, "fail");
+        assert_eq!(logged[0].failed, vec!["knip".to_owned()]);
+    }
+
+    #[test]
+    fn audit_write_failure_does_not_block_the_hook() {
+        // The OUTCOME constraint: a logging failure never propagates into the
+        // hook control flow. Point audit_dir under a regular file so
+        // create_dir_all fails, then a failing gate must still return its block
+        // JSON without panicking.
+        let tmp = setup_project(r#"{"gates":{"knip":true}}"#, &["package.json"]);
+
+        let bin_dir = tmp.join("node_modules/.bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let fake_knip = bin_dir.join("knip");
+        fs::write(&fake_knip, "#!/bin/sh\necho 'Unused export' >&2\nexit 1\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&fake_knip, fs::Permissions::from_mode(0o755)).unwrap();
+
+        // A file where the audit dir's parent should be → create_dir_all errors.
+        let blocker = tmp.join("blocker");
+        fs::write(&blocker, "").unwrap();
+        let audit_dir = blocker.join("audit");
+
+        let result = run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                audit_dir: Some(audit_dir),
+                ..Default::default()
+            },
+        );
+
+        assert!(result.is_some());
+        let json: serde_json::Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(json["decision"], "block");
+    }
+
+    #[test]
+    fn audit_records_pass_decision() {
+        let tmp = setup_project(r#"{"gates":{"lint":true}}"#, &["package.json"]);
+        fs::write(
+            tmp.join("package.json"),
+            r#"{"scripts":{"lint":"eslint ."}}"#,
+        )
+        .unwrap();
+        let audit_dir = tmp.join("audit");
+
+        run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                lint_cmd: Some("true".into()),
+                audit_dir: Some(audit_dir.clone()),
+                ..Default::default()
+            },
+        );
+
+        let logged = audit::query(&audit_dir, 20, None);
+        assert_eq!(logged.len(), 1);
+        assert_eq!(logged[0].decision, "pass");
+        assert!(logged[0].failed.is_empty());
+    }
+
+    #[test]
+    fn show_args_default_to_last_20_no_filter() {
+        let p = parse_show_args(&[]).unwrap();
+        assert_eq!(p.last, 20);
+        assert_eq!(p.decision, None);
+    }
+
+    #[test]
+    fn show_args_parse_last_and_decision() {
+        let args = ["--last", "5", "--decision", "fail"].map(str::to_owned);
+        let p = parse_show_args(&args).unwrap();
+        assert_eq!(p.last, 5);
+        assert_eq!(p.decision.as_deref(), Some("fail"));
+    }
+
+    #[test]
+    fn show_args_reject_invalid_decision() {
+        let args = ["--decision", "maybe"].map(str::to_owned);
+        assert!(parse_show_args(&args).is_err());
+    }
+
+    #[test]
+    fn show_args_reject_non_numeric_last() {
+        let args = ["--last", "x"].map(str::to_owned);
+        assert!(parse_show_args(&args).is_err());
+    }
+
+    #[test]
+    fn show_args_reject_unknown_flag() {
+        let args = ["--bogus".to_owned()];
+        assert!(parse_show_args(&args).is_err());
+    }
+
+    #[test]
+    fn audit_not_written_when_no_gate_runs() {
+        let tmp = setup_project(r#"{"gates":{}}"#, &["package.json"]);
+        let audit_dir = tmp.join("audit");
+
+        run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                audit_dir: Some(audit_dir.clone()),
+                ..Default::default()
+            },
+        );
+
+        assert!(audit::query(&audit_dir, 20, None).is_empty());
     }
 
     #[test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,3 +1,4 @@
+use crate::audit;
 use crate::circular;
 use crate::clone;
 use crate::coupling;
@@ -167,6 +168,9 @@ pub struct EnvOverrides {
     pub type_cmd: Option<String>,
     pub unit_cmd: Option<String>,
     pub test_cmd: Option<String>,
+    /// Directory for the audit log. Defaults to XDG resolution; tests inject a
+    /// temp dir so they never touch the real `~/.local/share/gates`.
+    pub audit_dir: Option<PathBuf>,
 }
 
 impl EnvOverrides {
@@ -176,6 +180,7 @@ impl EnvOverrides {
             type_cmd: env::var("TYPE_CMD").ok().filter(|s| !s.is_empty()),
             unit_cmd: env::var("UNIT_CMD").ok().filter(|s| !s.is_empty()),
             test_cmd: env::var("TEST_CMD").ok().filter(|s| !s.is_empty()),
+            audit_dir: audit::default_dir(),
         }
     }
 }


### PR DESCRIPTION
## 概要と目的

ゲートの pass/fail 判定を `$XDG_DATA_HOME/gates/audit.jsonl` へ永続化し、`gates show` でプロジェクト横断の失敗履歴を振り返れるようにする。これまで判定はその場限りで、どのプロジェクトがいつ何のゲートで落ちたかを後から追えなかった。

## 変更点

- `src/audit.rs` を新設: JSONL 追記 (`append`) / 絞り込み読み出し (`query`) / 整形 (`render`) / RFC3339 タイムスタンプ生成を集約。日付分解は Hinnant の `civil_from_days` を内製し依存ゼロ
- `gates show [--last N] [--decision pass|fail]` サブコマンドを追加 (既定 `--last 20`)
- ゲート実行のたびに `record_audit` で判定を追記。書き込み失敗は stderr 報告のみで hook をブロックしない (fail-open)
- 監査ディレクトリを `EnvOverrides` 経由で注入し、テストは temp dir を使い実ログに触れない

## 設計判断

- append は `writeln!` でなく単一 `write_all(line+\n)`。`writeln!` は本体と改行を別 syscall に分け、O_APPEND 下で並列 hook プロセスが行を混線させるため。8スレッド並列テストが旧実装で 20/20 失敗・新実装で pass することを確認
- RFC3339 整形に chrono を入れず内製: hook は編集ごとに起動するため起動コスト増を避ける

## テスト手順

1. `cargo test` → 190 tests green (`cargo clippy --all-targets` も clean)
2. 失敗するゲートのあるプロジェクトで `gates <dir>` を実行 → `audit.jsonl` に `decision:\"fail\"` 追記
3. `gates show --decision fail` → 失敗履歴が整形テーブルで表示される

## 関連

- Closes #10

https://claude.ai/code/session_019vBKgPPT9rh5sf6D5Wog9j