### PR TITLE
feat(exit-code): exit code を ADR-0066 Group 3 (Hook tool) に整合

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -170,6 +170,18 @@ gates /path/to/project  # ディレクトリを明示指定
 { "decision": "block", "reason": "lint failed. Fix lint errors.\n\nerror output..." }
 ```
 
+### 終了コード
+
+gates は ADR-0066 Group 3 (Hook tool) の終了コード規約に従い、PreToolUse の対である guardrails と共有します。PostToolUse hook 経路では decision surface は exit 0 を維持します。block 判定は stdout の `{"decision":"block"}` JSON で渡し (Claude Code がエージェントに供給)、pass は無音です。実際の非ゼロコードは直接 CLI 経路でのみ現れます。
+
+| 終了コード | 意味                                                               | 経路       |
+| ---------- | ------------------------------------------------------------------ | ---------- |
+| 0          | 全ゲート通過、または block 判定を stdout JSON で渡す               | hook + CLI |
+| 64         | `EX_USAGE`: 未知フラグ / 引数過多 / 非ディレクトリパス             | CLI        |
+| 74         | `EX_IOERR`: `gates show` の stdout 書込失敗 (BrokenPipe は exit 0) | `show`     |
+
+1 (advisory) / 2 (blocking) / 70 (`EX_SOFTWARE`, 内部障害) は将来の hook 仕様変更に備えて終了コード型に予約されています。現状の hook 経路では advisory/blocking は stdout JSON + exit 0 に対応し、内部障害は fail-open に吸収されます。
+
 ## 設定
 
 プロジェクトルートの `.claude/tools.json` に `gates` キーを追加します。

--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ No output means all gates passed. On failure, block JSON is printed to stdout:
 { "decision": "block", "reason": "lint failed. Fix lint errors.\n\nerror output..." }
 ```
 
+### Exit Codes
+
+gates follows the ADR-0066 Group 3 (Hook tool) exit-code convention, shared with its PreToolUse role-pair guardrails. On the PostToolUse hook path the decision surface stays exit 0: a blocking decision is delivered as stdout `{"decision":"block"}` JSON (which Claude Code feeds to the agent) and a pass is silent. Real non-zero codes appear only on the direct-CLI path.
+
+| Exit | Meaning                                                              | Path       |
+| ---- | -------------------------------------------------------------------- | ---------- |
+| 0    | All gates pass, or a blocking decision delivered via stdout JSON     | hook + CLI |
+| 64   | `EX_USAGE`: unknown flag, too many arguments, or non-directory path  | CLI        |
+| 74   | `EX_IOERR`: `gates show` failed to write stdout (BrokenPipe exits 0) | `show`     |
+
+Codes 1 (advisory), 2 (blocking), and 70 (`EX_SOFTWARE`, internal fault) are reserved in the exit-code type for a future hook-spec change. On the current hook path advisory/blocking map to stdout JSON + exit 0, and internal faults are absorbed by fail-open.
+
 ### Audit Log
 
 Every run appends its pass/fail decision to `$XDG_DATA_HOME/gates/audit.jsonl` (default `~/.local/share/gates/audit.jsonl`) as one JSON object per line. The write is fail-open, so a logging failure never blocks the agent.

--- a/src/hook_exit.rs
+++ b/src/hook_exit.rs
@@ -1,0 +1,86 @@
+//! Process exit codes per ADR-0066 Group 3 (Hook tool) convention, shared with
+//! the role-pair `guardrails` (PreToolUse). gates is the PostToolUse half, so
+//! its decision surface differs: a blocking decision is emitted as stdout
+//! `{"decision":"block"}` + exit 0 (the OUTCOME constraint and issue #18), not
+//! as a real exit 2. This enum encodes the Group 3 semantics at the type level
+//! so the mapping is explicit and switchable if the hook spec later requires
+//! distinct exit codes.
+//!
+//! | Exit | variant      | Meaning                              | Live on hook path? |
+//! |------|--------------|--------------------------------------|--------------------|
+//! | 0    | `Pass`       | all gates pass                       | yes                |
+//! | 1    | `Advisory`   | advisory failure (severity=warn)     | no (reserved)      |
+//! | 2    | `Blocking`   | blocking failure; child gate failed  | no (→ stdout JSON + exit 0) |
+//! | 64   | `InputError` | usage error / malformed hook input   | yes (CLI usage)    |
+//! | 70   | `Internal`   | internal panic / spawn failure       | no (fail-open → exit 0) |
+//!
+//! Only `InputError` (64) reaches a real process exit on the live paths, and
+//! only on direct-CLI usage errors (`gates a b c`, a non-directory argument) —
+//! the hook invocation (`gates`, dir = cwd) never trips them. On the hook path,
+//! `Blocking` is converted to stdout JSON + exit 0 by the caller, and any
+//! `Internal` fault is swallowed by fail-open (the gate is skipped, not raised).
+//! `Advisory` is reserved: every gate today is blocking. `EX_IOERR` (74) on the
+//! `gates show` path is an ADR-0060 I/O code orthogonal to this enum and lives
+//! as a separate constant.
+
+// `Pass`, `Advisory`, `Blocking`, and `Internal` are reserved at the type level
+// per issue #18: the hook wrapper keeps exit 0 for the decision surface and
+// fail-open swallows internal faults, so only `InputError` reaches a live exit
+// today. The full Group 3 mapping is kept so a future hook-spec change can
+// switch the surface without redefining the type.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookExitCode {
+    Pass,
+    Advisory,
+    Blocking,
+    InputError,
+    Internal,
+}
+
+impl HookExitCode {
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::Pass => 0,
+            Self::Advisory => 1,
+            Self::Blocking => 2,
+            Self::InputError => 64,
+            Self::Internal => 70,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HookExitCode;
+
+    // T-101: Pass maps to sysexits EX_OK (0).
+    #[test]
+    fn pass_is_zero() {
+        assert_eq!(HookExitCode::Pass.code(), 0);
+    }
+
+    // T-102: Advisory maps to 1 (severity=warn convention).
+    #[test]
+    fn advisory_is_one() {
+        assert_eq!(HookExitCode::Advisory.code(), 1);
+    }
+
+    // T-103: Blocking maps to 2 (severity=error / child gate failed).
+    #[test]
+    fn blocking_is_two() {
+        assert_eq!(HookExitCode::Blocking.code(), 2);
+    }
+
+    // T-104: InputError maps to sysexits EX_USAGE (64).
+    #[test]
+    fn input_error_is_sysexits_usage() {
+        assert_eq!(HookExitCode::InputError.code(), 64);
+    }
+
+    // T-105: Internal maps to sysexits EX_SOFTWARE (70).
+    #[test]
+    fn internal_is_sysexits_software() {
+        assert_eq!(HookExitCode::Internal.code(), 70);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod color;
 mod config;
 mod coupling;
 mod depgraph;
+mod hook_exit;
 mod project;
 mod reporter;
 mod resolve;
@@ -21,10 +22,17 @@ use std::path::Path;
 use std::process;
 use std::thread;
 
-/// sysexits.h codes used on the `gates show` CLI path. The hook path stays on
-/// 0 (protocol JSON) / 1 (main usage) per the OUTCOME constraint; only the
-/// agent-invoked `show` subcommand adopts sysexits (ADR-0060, #14).
-const EX_USAGE: i32 = 64;
+use hook_exit::HookExitCode;
+
+/// Usage / not-a-directory errors exit with `EX_USAGE` (64) per ADR-0066
+/// Group 3 (#18), on both the direct-CLI default path and the `show`
+/// subcommand. The hook invocation (`gates`, dir = cwd) never trips these.
+fn ex_usage() -> i32 {
+    i32::from(HookExitCode::InputError.code())
+}
+
+/// sysexits `EX_IOERR`, used when `gates show` fails to write stdout. This is an
+/// ADR-0060 I/O code (#14) orthogonal to the Group 3 hook exit semantics.
 const EX_IOERR: i32 = 74;
 
 const CONFIG_HINT: &str = "Gates: using defaults. Customize via .claude/tools.json \u{2014} see https://github.com/thkt/gates#configuration";
@@ -451,7 +459,7 @@ fn run_show(args: &[String]) -> i32 {
         Ok(p) => p,
         Err(e) => {
             eprintln!("gates: {e}\n{SHOW_USAGE}");
-            return EX_USAGE;
+            return ex_usage();
         }
     };
     // A None dir (neither XDG_DATA_HOME nor HOME set) yields no entries, the
@@ -481,7 +489,7 @@ fn main() {
         let project_dir = Path::new(dir);
         if !project_dir.is_dir() {
             eprintln!("gates: not a directory: {}", project_dir.display());
-            process::exit(1);
+            process::exit(ex_usage());
         }
         if let Some(json) = run_post_bash(project_dir, &tools::EnvOverrides::from_env()) {
             println!("{json}");
@@ -491,14 +499,14 @@ fn main() {
 
     if args.len() > 2 {
         eprintln!("usage: gates [project_dir]");
-        process::exit(1);
+        process::exit(ex_usage());
     }
 
     let dir = args.get(1).map(String::as_str).unwrap_or(".");
     let project_dir = Path::new(dir);
     if !project_dir.is_dir() {
         eprintln!("gates: not a directory: {}", project_dir.display());
-        process::exit(1);
+        process::exit(ex_usage());
     }
 
     if let Some(json) = run(project_dir) {
@@ -1096,7 +1104,7 @@ mod tests {
 
     #[test]
     fn run_show_rejects_unknown_flag_with_ex_usage() {
-        assert_eq!(run_show(&["--bogus".to_owned()]), EX_USAGE);
+        assert_eq!(run_show(&["--bogus".to_owned()]), ex_usage());
     }
 
     #[test]
@@ -1221,5 +1229,60 @@ mod tests {
             reason.contains("Banned"),
             "fix prompt should include footer"
         );
+    }
+
+    // T-111: when two gates fail concurrently (knip on its own thread, lint on
+    // the script-gate thread), the decision surface stays exit 0 + stdout JSON:
+    // run returns Some(block JSON) listing both failed gates. Group 3 maps a
+    // blocking decision to HookExitCode::Blocking (2) at the type level, but the
+    // hook wrapper keeps exit 0 — so the testable surface is the returned JSON,
+    // not a process exit code (#18).
+    #[test]
+    fn parallel_gate_failures_return_block_json_listing_both() {
+        let tmp = setup_project(r#"{"gates":{"knip":true,"lint":true}}"#, &["package.json"]);
+        fs::write(
+            tmp.join("package.json"),
+            r#"{"scripts":{"lint":"eslint ."}}"#,
+        )
+        .unwrap();
+
+        let bin_dir = tmp.join("node_modules/.bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let fake_knip = bin_dir.join("knip");
+        fs::write(&fake_knip, "#!/bin/sh\necho 'Unused export' >&2\nexit 1\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&fake_knip, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let result = run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                lint_cmd: Some("sh -c 'echo lint-error && exit 1'".into()),
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            result.is_some(),
+            "parallel failures should block (exit 0 + JSON)"
+        );
+        let json: serde_json::Value = serde_json::from_str(&result.unwrap()).unwrap();
+        assert_eq!(json["decision"], "block");
+        let reason = json["reason"].as_str().unwrap();
+        assert!(
+            reason.contains("knip"),
+            "reason should list the failed knip gate"
+        );
+        assert!(
+            reason.contains("lint"),
+            "reason should list the failed lint gate"
+        );
+    }
+
+    // T-110 companion: usage errors exit with EX_USAGE (64) per Group 3, the
+    // same code the show path returns. Guards the ex_usage() helper that the
+    // three main() usage/not-a-dir paths share.
+    #[test]
+    fn usage_errors_use_ex_usage_64() {
+        assert_eq!(ex_usage(), 64);
     }
 }


### PR DESCRIPTION
Closes #18

## 概要

Group 3 (Hook tool) の exit-code 語彙 (0=pass / 1=advisory / 2=blocking / 64=EX_USAGE / 70=EX_SOFTWARE) を `HookExitCode` 型に集約。PreToolUse の役割対 guardrails とローカルミラーで共有 (amici 非依存、issue #18 コメント「ADR-0066 にすり合わせる」に従う)。

## 設計

gates は PostToolUse 側のため decision surface は exit 0 を維持 (block は stdout JSON に変換、pass は無音)。enum は共有する型、表面 (surface) は hook 種別で分岐する。guardrails は real exit code (PreToolUse exit 2 が実際にブロック)、gates は stdout JSON + exit 0 (PostToolUse でモデルに届く唯一の経路)。

## #18 受け入れ条件の項目別解決

| 項目 | 受け入れ条件 | 解決 |
| ---- | ------------ | ---- |
| 1 | CliError 型実装 | `HookExitCode` をローカル実装 (guardrails ミラー、amici 非依存) |
| 2 | 子プロセス失敗→2 mapping | 型レベルで Blocking=2 を予約。hook 経路では stdout JSON + exit 0 に変換 |
| 3 | 入力 JSON 不正→64 独立 | InputError=64 として独立 (direct-CLI usage error) |
| 4 | spawn 失敗等→70 | 型レベルで Internal=70 を予約。live hook 経路は fail-open が skipped に吸収する (core outcome「スレッドパニックでブロックしない」)。literal な 70 return は outcome 違反かつ PostToolUse で 70 は non-blocking notice ゆえ機能的に無効 |
| 5 | 並列 fail exit code テスト | T-111 を追加 |
| 6 | README exit code 表 | README.md / README.ja.md に追加 |

## 強制力に関する注記 (TD-1)

enum は `process::exit` 境界で i32 へ decay し、guardrails (main.rs:99/115/124、`fn exit` なし) と一致する。型が境界を所有する形は #18 スコープ外。gates 単独の `fn exit` は役割対 parity を壊し、EX_IOERR=74 (ADR-0060) は元々この enum 外を流れる。両ツール横断の follow-up として別途検討する。

## テスト

226 passed / fmt clean / clippy clean

https://claude.ai/code/session_01W5fxUpCLQVQQtwJh2wTXFm