### PR TITLE
update-sentinels の認証を PAT から GitHub App token に移行する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,11 +187,22 @@ jobs:
       contents: read
 
     steps:
+      - name: Generate sentinels App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SENTINELS_APP_ID }}
+          private-key: ${{ secrets.SENTINELS_APP_PRIVATE_KEY }}
+          owner: thkt
+          repositories: sentinels
+          permission-contents: write
+
       - name: Checkout sentinels
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: thkt/sentinels
-          token: ${{ secrets.SENTINELS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Update plugin version
         env:
@@ -206,9 +217,11 @@ jobs:
         env:
           VERSION: ${{ needs.release.outputs.version }}
           TOOL: gates
+          TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/thkt/sentinels.git"
           git add "${TOOL}/.claude-plugin/plugin.json"
           git diff --staged --quiet && echo "No changes to commit" && exit 0
           git commit -m "sync: ${TOOL} v${VERSION}"


### PR DESCRIPTION
## 概要と背景

release.yml の `update-sentinels` job が `secrets.SENTINELS_TOKEN` (PAT) で sentinels リポへ push していたのを、`actions/create-github-app-token` で生成した GitHub App token に移行する。PAT はアカウント権限スコープ依存で期限切れ・無効化リスクが個人依存になるが、App token は repository 単位で権限を絞れ rotation も App 側で集中管理できる。guardrails の同 job と方式を揃える。

## 変更点

- App token 生成 step (`app-token`) を checkout 前に追加 (owner: thkt / repositories: sentinels / permission-contents: write)
- checkout の `token` を `steps.app-token.outputs.token` に置換し `persist-credentials: false` を追加
- Commit and push を `git remote set-url origin` で x-access-token 経由に切替 (`TOKEN` env 追加)

## スコープ

- **含まないもの**: secret 設定 (`SENTINELS_APP_ID` / `SENTINELS_APP_PRIVATE_KEY`) と PAT 削除は App private key 値が必要なリポジトリ管理操作のため本 PR 外。下記「merge 前提条件」を参照。

## 設計判断

- **検証済み**: guardrails が同一 App (`SENTINELS_APP_ID` / `SENTINELS_APP_PRIVATE_KEY`, 2026-05-19 17:08 設定) で sentinels に sync 済み。設定直後の `sync: guardrails v0.15.0` から最新 v0.19.0 (2026-06-18) まで github-actions[bot] で push 成功しており、App が sentinels リポに contents:write でインストール済みであることが実証されている。よって新規 App は不要、gates に同じ値の secret を設定すれば足りる。
- 移行検証が次回リリースで取れるまで PAT (`SENTINELS_TOKEN`) は残し、ロールバック経路を確保する。

## merge 前提条件 (ユーザー作業 / 順序厳守)

1. gates リポに secret を設定: `gh secret set SENTINELS_APP_ID --repo thkt/gates` / `gh secret set SENTINELS_APP_PRIVATE_KEY --repo thkt/gates < private-key.pem`
2. **secret 設定後に merge** (未設定のまま次タグを切ると App token 生成 step で失敗)
3. 次回リリースで `update-sentinels` の成功を確認した後、`gh secret delete SENTINELS_TOKEN --repo thkt/gates` で PAT を削除

## 動作確認手順

1. 上記 secret を設定して merge
2. 次回 `v*` タグ push で Release workflow を発火
3. `update-sentinels` job の App token 生成 step が成功し、sentinels リポの `gates/.claude-plugin/plugin.json` の version が更新・push されることを確認

## 関連

- Refs #28
- 参考: guardrails `.github/workflows/release.yml` の `update-sentinels` job
- Phase 5 PR: #26

https://claude.ai/code/session_01W5fxUpCLQVQQtwJh2wTXFm