### PR TITLE
sentinels の binaries ブランチへバイナリを配布する publish-binaries job を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,3 +226,87 @@ jobs:
           git diff --staged --quiet && echo "No changes to commit" && exit 0
           git commit -m "sync: ${TOOL} v${VERSION}"
           git push
+
+  publish-binaries-to-sentinels:
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: publish-binaries-to-sentinels
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    env:
+      TOOL: gates
+
+    steps:
+      - name: Generate sentinels App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SENTINELS_APP_ID }}
+          private-key: ${{ secrets.SENTINELS_APP_PRIVATE_KEY }}
+          owner: thkt
+          repositories: sentinels
+          permission-contents: write
+
+      - name: Checkout sentinels
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: thkt/sentinels
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/artifacts
+
+      - name: Stage binaries (preserve other tools, exclude Windows)
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          STAGE=/tmp/binaries-stage
+          mkdir -p "$STAGE"
+
+          git remote set-url origin "https://x-access-token:${TOKEN}@github.com/thkt/sentinels.git"
+
+          # Preserve other tools' files from existing binaries branch (if present)
+          if git fetch --depth=1 origin binaries:refs/remotes/origin/binaries 2>/dev/null; then
+            git worktree add /tmp/old-binaries origin/binaries
+            (cd /tmp/old-binaries && tar cf - --exclude=.git --exclude="$TOOL" .) | (cd "$STAGE" && tar xf -)
+            git worktree remove --force /tmp/old-binaries
+          fi
+
+          # Place this tool's binaries (Unix only; Windows excluded)
+          mkdir -p "$STAGE/$TOOL/bin"
+          find /tmp/artifacts -name '*.tar.gz' ! -path '*windows*' -exec cp {} "$STAGE/$TOOL/bin/" \;
+
+          # SHA-256 manifest so downstream consumers can verify tarball
+          # integrity against a tampered binaries branch.
+          (cd "$STAGE/$TOOL/bin" && sha256sum ./*.tar.gz > checksums.txt)
+
+          echo "--- Staged content ---"
+          find "$STAGE" -type f | sort
+          echo "--- checksums.txt ---"
+          cat "$STAGE/$TOOL/bin/checksums.txt"
+
+      - name: Force-push binaries branch
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Switch workspace to a fresh orphan branch (history reset to single commit)
+          git checkout --orphan binaries-new
+          git rm -rf --cached . 2>/dev/null || true
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+
+          # Copy staged content (other tools + this tool's new binaries)
+          cp -r /tmp/binaries-stage/. .
+
+          git add -A
+          git commit -m "binaries: ${TOOL} v${VERSION}"
+          git push -f origin binaries-new:binaries


### PR DESCRIPTION
## 概要

リリース時に gates のクロスコンパイル済みバイナリを thkt/sentinels の orphan `binaries` ブランチへ force-push する `publish-binaries-to-sentinels` job を追加する。`claude plugins install` 直後に追加ダウンロードなしで gates を実行可能にするため。

## 背景

guardrails ADR-0002 (accepted 2026-05-13) が orphan-branch mirror 方式を 4 ツール共通フロー (guardrails / formatter / reviews / gates) として確定済み。ADR は `claude plugins install` が shallow clone である実測に基づき、main 履歴を汚さず remote 容量を「最新 1 リリース分 × ツール数」で頭打ちにできる D 案を採択し、sentinels GitHub Release 同梱案 (C) を却下した。本 PR はその gates 側実装。

#29 第1チェックボックス「sentinels 側 binaries プロトコル合意確認」は ADR-0002 が満たす (sentinels#2 の Release-pull 案より新しく、これを supersede)。

## 変更内容

- `release` job 後段に `publish-binaries-to-sentinels` を追加
- 4 Unix tarball (Windows 除外) を `gates/bin/` に配置、他ツールのファイルは保持
- `sha256sum` で `checksums.txt` 生成 (改竄検出)
- orphan `binaries-new` を force-push で `binaries` にリセット

guardrails の同 job の忠実な移植で、差分は `TOOL=gates` のみ。

## テスト

- `actionlint .github/workflows/release.yml` → OK
- `zizmor .github/workflows/release.yml` → No findings (3 ignored, 13 suppressed)
- guardrails job との diff → `TOOL` 値のみ

## レビュー観点

- App token (`SENTINELS_APP_ID` / `SENTINELS_APP_PRIVATE_KEY`) は #57 で移行済みの既存 secret を流用
- consumer 側 (sentinels `install-lib.sh` の binaries fetch) は別 issue 管理・未実装。publisher は guardrails も consumer 未完成のまま稼働中で独立に追加可能

Closes #29

https://claude.ai/code/session_01W5fxUpCLQVQQtwJh2wTXFm