### PR TITLE
feat(gates): oxlint --type-aware 静的ゲートを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 # gates
 
-Claude Codeの[PostToolUseフック](https://docs.anthropic.com/en/docs/claude-code/hooks)用品質ゲート。lint・type-check・test・knip・tsgo・dependency-cruiser・litmus・循環依存検出をWrite/Edit/MultiEditのたびに並列実行し、失敗時にエージェントへフィードバックを返します。
+Claude Codeの[PostToolUseフック](https://docs.anthropic.com/en/docs/claude-code/hooks)用品質ゲート。lint・type-check・test・knip・tsgo・oxlint type-aware lint・dependency-cruiser・litmus・循環依存検出をWrite/Edit/MultiEditのたびに並列実行し、失敗時にエージェントへフィードバックを返します。
 
 ## 特徴
 
@@ -33,11 +33,12 @@ Claude Codeの[PostToolUseフック](https://docs.anthropic.com/en/docs/claude-c
 
 `node_modules/.bin` から解決し、見つからなければ `$PATH` にフォールバックします。
 
-| ゲート    | 条件                                         | 引数     |
-| --------- | -------------------------------------------- | -------- |
-| knip      | `package.json` あり                          | （なし） |
-| tsgo      | `tsconfig.json` あり                         | （なし） |
-| depcruise | `.dependency-cruiser.{js,cjs,mjs,json}` あり | `src/`   |
+| ゲート    | 条件                                             | 引数                            |
+| --------- | ------------------------------------------------ | ------------------------------- |
+| knip      | `package.json` あり                              | （なし）                        |
+| tsgo      | `tsconfig.json` あり                             | （なし）                        |
+| oxlint    | `tsconfig.json` あり かつ `oxlint-tsgolint` 検出 | `--type-aware --max-warnings 0` |
+| depcruise | `.dependency-cruiser.{js,cjs,mjs,json}` あり     | `src/`                          |
 
 ### 組み込みゲート
 
@@ -64,11 +65,12 @@ Claude Codeの[PostToolUseフック](https://docs.anthropic.com/en/docs/claude-c
 
 使いたいゲートに対応するツールをインストールしてください。
 
-| ツール                                                               | インストール                                              |
-| -------------------------------------------------------------------- | --------------------------------------------------------- |
-| [knip](https://knip.dev)                                             | `npm i -D knip`（プロジェクトローカル推奨）               |
-| [tsgo](https://github.com/microsoft/typescript-go)                   | `npm i -g @typescript/native-preview`                     |
-| [dependency-cruiser](https://github.com/sverweij/dependency-cruiser) | `npm i -D dependency-cruiser`（プロジェクトローカル推奨） |
+| ツール                                                               | インストール                                                  |
+| -------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [knip](https://knip.dev)                                             | `npm i -D knip`（プロジェクトローカル推奨）                   |
+| [tsgo](https://github.com/microsoft/typescript-go)                   | `npm i -g @typescript/native-preview`                         |
+| [oxlint](https://oxc.rs/docs/guide/usage/linter/type-aware.html)     | `npm i -D oxlint oxlint-tsgolint`（プロジェクトローカル推奨） |
+| [dependency-cruiser](https://github.com/sverweij/dependency-cruiser) | `npm i -D dependency-cruiser`（プロジェクトローカル推奨）     |
 
 [litmus](https://github.com/thkt/litmus) と循環依存検出は `gates` バイナリに内蔵されています。個別インストールは不要です。
 
@@ -193,6 +195,7 @@ gates は ADR-0066 Group 3 (Hook tool) の終了コード規約に従い、PreTo
   "gates": {
     "knip": true,
     "tsgo": true,
+    "oxlint": true,
     "depcruise": true,
     "circular": true,
     "litmus": true,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gates
 
-Quality gates for Claude Code [PostToolUse hooks](https://docs.anthropic.com/en/docs/claude-code/hooks). Runs lint, type-check, test, knip, tsgo, dependency-cruiser, litmus, circular dependency detection, coupling metrics, and structural clone detection in parallel after each Write/Edit/MultiEdit, providing failure feedback to guide the agent.
+Quality gates for Claude Code [PostToolUse hooks](https://docs.anthropic.com/en/docs/claude-code/hooks). Runs lint, type-check, test, knip, tsgo, oxlint type-aware lint, dependency-cruiser, litmus, circular dependency detection, coupling metrics, and structural clone detection in parallel after each Write/Edit/MultiEdit, providing failure feedback to guide the agent.
 
 ## Features
 
@@ -33,11 +33,12 @@ Agent calls Write/Edit/MultiEdit → PostToolUse hook fires → gates binary run
 
 Resolved from `node_modules/.bin`, falling back to `$PATH`.
 
-| Gate      | Condition                                      | Args   |
-| --------- | ---------------------------------------------- | ------ |
-| knip      | `package.json` exists                          | (none) |
-| tsgo      | `tsconfig.json` exists                         | (none) |
-| depcruise | `.dependency-cruiser.{js,cjs,mjs,json}` exists | `src/` |
+| Gate      | Condition                                          | Args                            |
+| --------- | -------------------------------------------------- | ------------------------------- |
+| knip      | `package.json` exists                              | (none)                          |
+| tsgo      | `tsconfig.json` exists                             | (none)                          |
+| oxlint    | `tsconfig.json` exists and `oxlint-tsgolint` found | `--type-aware --max-warnings 0` |
+| depcruise | `.dependency-cruiser.{js,cjs,mjs,json}` exists     | `src/`                          |
 
 ### Embedded Gates
 
@@ -66,11 +67,12 @@ When no lock file is found, script gates are silently skipped (fail-open). Envir
 
 Install the tools for the gates you want to use.
 
-| Tool                                                                 | Install                                       |
-| -------------------------------------------------------------------- | --------------------------------------------- |
-| [knip](https://knip.dev)                                             | `npm i -D knip` (project-local)               |
-| [tsgo](https://github.com/microsoft/typescript-go)                   | `npm i -g @typescript/native-preview`         |
-| [dependency-cruiser](https://github.com/sverweij/dependency-cruiser) | `npm i -D dependency-cruiser` (project-local) |
+| Tool                                                                 | Install                                           |
+| -------------------------------------------------------------------- | ------------------------------------------------- |
+| [knip](https://knip.dev)                                             | `npm i -D knip` (project-local)                   |
+| [tsgo](https://github.com/microsoft/typescript-go)                   | `npm i -g @typescript/native-preview`             |
+| [oxlint](https://oxc.rs/docs/guide/usage/linter/type-aware.html)     | `npm i -D oxlint oxlint-tsgolint` (project-local) |
+| [dependency-cruiser](https://github.com/sverweij/dependency-cruiser) | `npm i -D dependency-cruiser` (project-local)     |
 
 [litmus](https://github.com/thkt/litmus) and circular dependency detection are embedded in the `gates` binary — no separate installation needed.
 
@@ -222,6 +224,7 @@ When no config file exists, all gates run by default. Once you create `.claude/t
   "gates": {
     "knip": true,
     "tsgo": true,
+    "oxlint": true,
     "depcruise": true,
     "circular": true,
     "coupling": true,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -123,7 +123,23 @@ pub const INSTALL_COMMANDS: &[InstallInfo] = &[
         name: "tsgo",
         install: "npm i -g @typescript/native-preview",
     },
+    InstallInfo {
+        name: "oxlint",
+        install: "npm i -D oxlint oxlint-tsgolint",
+    },
 ];
+
+/// `oxlint --type-aware` shells out to the project-local `tsgolint` backend. When it is
+/// absent, oxlint exits nonzero with "Failed to find tsgolint executable" — which the
+/// runner maps to a false `block` (it cannot tell a tool-launch failure from a real
+/// violation). Gate the oxlint gate on tsgolint being resolvable so a tsconfig project
+/// without it stays fail-open (skipped). Issue #31 AC: oxlint/tsgolint absence → skipped.
+///
+/// `resolve_bin` returns the bare name unchanged only on its not-found fallback, so any
+/// other value means it resolved an executable `node_modules/.bin/tsgolint`.
+fn tsgolint_available(root: &Path) -> bool {
+    resolve::resolve_bin("tsgolint", root) != Path::new("tsgolint")
+}
 
 pub const GATES: &[GateDefinition] = &[
     GateDefinition {
@@ -139,6 +155,18 @@ pub const GATES: &[GateDefinition] = &[
         args: &[],
         hint: "Fix type errors.",
         condition: |p| p.has_tsconfig,
+    },
+    // Type-aware lint (backend: tsgolint). `--max-warnings 0` promotes oxlint's
+    // default-severity findings (type-aware rules emit as warnings) to a nonzero
+    // exit so the gate blocks; `--type-check` is omitted to avoid double-reporting
+    // type errors with the tsgo gate. Rule-set tuning is deferred (issue #31).
+    // https://oxc.rs/docs/guide/usage/linter/type-aware.html
+    GateDefinition {
+        name: "oxlint",
+        command: "oxlint",
+        args: &["--type-aware", "--max-warnings", "0"],
+        hint: "Fix type-aware lint violations (e.g. floating promises).",
+        condition: |p| p.has_tsconfig && tsgolint_available(&p.root),
     },
     // dependency-cruiser auto-detects .dependency-cruiser.{js,cjs,mjs,json} since v13,
     // so --config is omitted; the condition gates on the same four formats it detects.
@@ -1161,6 +1189,72 @@ mod tests {
         let gate = gate_by_name("depcruise");
         assert_eq!(gate.command, "dependency-cruiser");
         assert_eq!(gate.args, &["src/"]);
+    }
+
+    /// Builds a tsconfig project, optionally planting an executable
+    /// `node_modules/.bin/tsgolint` — the signal the oxlint gate uses to decide
+    /// whether its `--type-aware` backend can run.
+    fn oxlint_project(with_tsgolint: bool) -> (TempDir, ProjectInfo) {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new("oxlint");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        if with_tsgolint {
+            let bin_dir = tmp.join("node_modules/.bin");
+            fs::create_dir_all(&bin_dir).unwrap();
+            let bin = bin_dir.join("tsgolint");
+            fs::write(&bin, "").unwrap();
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: false,
+            has_tsconfig: true,
+        };
+        (tmp, project)
+    }
+
+    #[test]
+    fn oxlint_condition_true_with_tsconfig_and_tsgolint() {
+        let (_tmp, project) = oxlint_project(true);
+        assert!((gate_by_name("oxlint").condition)(&project));
+    }
+
+    #[test]
+    fn oxlint_condition_false_when_tsgolint_absent() {
+        let (_tmp, project) = oxlint_project(false);
+        assert!(
+            !(gate_by_name("oxlint").condition)(&project),
+            "missing tsgolint must keep the gate fail-open (skipped), not false-block"
+        );
+    }
+
+    #[test]
+    fn oxlint_condition_false_without_tsconfig() {
+        let (_tmp, mut project) = oxlint_project(true);
+        project.has_tsconfig = false;
+        assert!(
+            !(gate_by_name("oxlint").condition)(&project),
+            "tsconfig is required even when tsgolint is present"
+        );
+    }
+
+    #[test]
+    fn oxlint_skips_when_tsgolint_absent() {
+        let (_tmp, project) = oxlint_project(false);
+        let result = run_gate(gate_by_name("oxlint"), &project);
+        assert!(
+            result.is_skipped(),
+            "tsconfig project without tsgolint must skip, not block"
+        );
+    }
+
+    #[test]
+    fn oxlint_definition_uses_type_aware_without_type_check() {
+        // Locks the exit-code contract: --max-warnings 0 makes warnings block, and
+        // --type-check is omitted so type errors are not double-reported with tsgo.
+        let gate = gate_by_name("oxlint");
+        assert_eq!(gate.command, "oxlint");
+        assert_eq!(gate.args, &["--type-aware", "--max-warnings", "0"]);
     }
 
     fn run_circular(project: &ProjectInfo) -> ToolResult {


### PR DESCRIPTION
## 概要

`oxlint --type-aware` を Static Gate として追加。単一ファイル解析では検出できない型認識 lint 違反 (例: `no-floating-promises`) を PostToolUse 時に検出する。Closes #31.

## 仕組み

- 条件: `tsconfig.json` 存在 かつ `oxlint-tsgolint` (tsgolint バイナリ) を `resolve_bin` で検出できる場合のみ発火
- 引数: `--type-aware --max-warnings 0` (`--type-check` は付けず tsgo との二重報告を回避。`--max-warnings 0` で warning を非ゼロ exit に昇格)
- fail-open: tsgolint 不在なら gate を skip。バイナリ欠如で誤ブロックしない

## 検証

- AC#1 floating-promise 検出: ✓
- AC#2 型エラー二重報告なし: ✓
- AC#3 fail-open: tsgolint 不在で skip、かつ本番同等 PATH (project-local `node_modules/.bin` 非搭載) でも oxlint が cwd からの Node module 解決で tsgolint を発見し誤ブロックなし: ✓
- AC#4 `.claude/tools.json` トグル: ✓
- 231 tests pass / clippy clean

## 既知の制約

検証は homebrew global oxlint + project-local tsgolint 構成で実施。将来 oxlint が tsgolint 解決方式を PATH 依存へ変更した場合は再検証が必要 (現状の oxlint では PATH 非依存)。

https://claude.ai/code/session_01W5fxUpCLQVQQtwJh2wTXFm
