### PR TITLE
[Bug] write-then-exec レースで knip 系テストが llvm-cov 計装下で ETXTBSY flaky に落ちる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,10 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Install cargo-llvm-cov
+      - name: Install cargo-llvm-cov and nextest
         uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov,cargo-nextest
 
       - name: Coverage delta gate (project C0 must not drop vs main)
         run: |
@@ -88,12 +88,23 @@ jobs:
           # HEAD = PR merged into main (the checked-out pull_request ref).
           # cargo llvm-cov cleans stale profraw at the start of each run, so the
           # two measurements below do not mix.
-          cargo llvm-cov --ignore-filename-regex 'src/test_utils\.rs$' --lcov --output-path head.info
+          # Run via nextest (process-per-test), not libtest (thread-per-test): #59.
+          # libtest runs every test in one process, so a thread writing a fake bin
+          # holds a writable fd that a sibling thread's Command::spawn fork()
+          # inherits; the later exec of that bin then trips ETXTBSY
+          # (deny_write_access). llvm-cov instrumentation widens the window enough
+          # to flake. nextest isolates each test in its own process, so no sibling
+          # shares the fd table and the cross-test fd inheritance cannot happen.
+          # This matches the test job's runner and fixes both head and base
+          # (base still runs main's pre-fix write-then-exec paths until #59 lands).
+          # gates has no lib target, so there are no doctests for nextest to skip;
+          # coverage stays equivalent to the libtest run.
+          cargo llvm-cov nextest --profile ci --ignore-filename-regex 'src/test_utils\.rs$' --lcov --output-path head.info
           head_c0=$(c0 head.info)
           # BASE = main (fetch-depth:0 already has the history).
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           git checkout --quiet --force origin/main
-          cargo llvm-cov --ignore-filename-regex 'src/test_utils\.rs$' --lcov --output-path base.info
+          cargo llvm-cov nextest --profile ci --ignore-filename-regex 'src/test_utils\.rs$' --lcov --output-path base.info
           base_c0=$(c0 base.info)
           # 0.1pp tolerance absorbs instrumentation rounding / total line drift.
           awk -v b="$base_c0" -v h="$head_c0" 'BEGIN {

--- a/src/main.rs
+++ b/src/main.rs
@@ -570,12 +570,7 @@ mod tests {
     // the digest matches and the run is skipped, it returns None.
     fn setup_failing_knip() -> TempDir {
         let tmp = setup_project(r#"{"gates":{"knip":true}}"#, &["package.json"]);
-        let bin_dir = tmp.join("node_modules/.bin");
-        fs::create_dir_all(&bin_dir).unwrap();
-        let fake_knip = bin_dir.join("knip");
-        fs::write(&fake_knip, "#!/bin/sh\necho 'Unused export' >&2\nexit 1\n").unwrap();
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&fake_knip, fs::Permissions::from_mode(0o755)).unwrap();
+        test_utils::link_fake_bin(&tmp, "knip", "knip-unused-export");
         tmp
     }
 
@@ -714,12 +709,7 @@ mod tests {
     // file would never match the stored digest and every Bash call would re-run.
     fn setup_emitting_knip() -> TempDir {
         let tmp = setup_project(r#"{"gates":{"knip":true}}"#, &["package.json"]);
-        let bin_dir = tmp.join("node_modules/.bin");
-        fs::create_dir_all(&bin_dir).unwrap();
-        let fake_knip = bin_dir.join("knip");
-        fs::write(&fake_knip, "#!/bin/sh\necho 'emit' > out.js\nexit 1\n").unwrap();
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&fake_knip, fs::Permissions::from_mode(0o755)).unwrap();
+        test_utils::link_fake_bin(&tmp, "knip", "knip-emit");
         tmp
     }
 
@@ -959,13 +949,7 @@ mod tests {
     fn failing_gate_returns_block_json() {
         let tmp = setup_project(r#"{"gates":{"knip":true}}"#, &["package.json"]);
 
-        let bin_dir = tmp.join("node_modules/.bin");
-        fs::create_dir_all(&bin_dir).unwrap();
-        let fake_knip = bin_dir.join("knip");
-        fs::write(&fake_knip, "#!/bin/sh\necho 'Unused export' >&2\nexit 1\n").unwrap();
-
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&fake_knip, fs::Permissions::from_mode(0o755)).unwrap();
+        test_utils::link_fake_bin(&tmp, "knip", "knip-unused-export");
 
         let audit_dir = tmp.join("audit");
         let result = run_with_overrides(
@@ -995,12 +979,7 @@ mod tests {
         // JSON without panicking.
         let tmp = setup_project(r#"{"gates":{"knip":true}}"#, &["package.json"]);
 
-        let bin_dir = tmp.join("node_modules/.bin");
-        fs::create_dir_all(&bin_dir).unwrap();
-        let fake_knip = bin_dir.join("knip");
-        fs::write(&fake_knip, "#!/bin/sh\necho 'Unused export' >&2\nexit 1\n").unwrap();
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&fake_knip, fs::Permissions::from_mode(0o755)).unwrap();
+        test_utils::link_fake_bin(&tmp, "knip", "knip-unused-export");
 
         // A file where the audit dir's parent should be → create_dir_all errors.
         let blocker = tmp.join("blocker");
@@ -1246,12 +1225,7 @@ mod tests {
         )
         .unwrap();
 
-        let bin_dir = tmp.join("node_modules/.bin");
-        fs::create_dir_all(&bin_dir).unwrap();
-        let fake_knip = bin_dir.join("knip");
-        fs::write(&fake_knip, "#!/bin/sh\necho 'Unused export' >&2\nexit 1\n").unwrap();
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&fake_knip, fs::Permissions::from_mode(0o755)).unwrap();
+        test_utils::link_fake_bin(&tmp, "knip", "knip-unused-export");
 
         let result = run_with_overrides(
             &tmp,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::ops::Deref;
+use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -37,4 +38,25 @@ impl Deref for TempDir {
     fn deref(&self) -> &Path {
         &self.path
     }
+}
+
+/// Symlink a committed, exec-only fixture from `tests/fixtures/<fixture>` to
+/// `<project>/node_modules/.bin/<bin_name>`. The exec target is never written
+/// during the test, so no parallel fork can hold a writable fd to the file the
+/// gate execs — structurally removing the write-then-exec ETXTBSY race that
+/// `fs::write` + `set_permissions` + exec hit under llvm-cov instrumentation (#59).
+pub fn link_fake_bin(project: &Path, bin_name: &str, fixture: &str) {
+    let bin_dir = project.join("node_modules/.bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(fixture);
+    // symlink does not validate its target; assert first so a missing or
+    // renamed fixture fails here with the path, not later as an opaque exec error.
+    assert!(
+        fixture_path.exists(),
+        "missing fixture: {}",
+        fixture_path.display()
+    );
+    symlink(&fixture_path, bin_dir.join(bin_name)).unwrap();
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -896,7 +896,7 @@ pub fn run_gate(gate: &GateDefinition, project: &ProjectInfo) -> ToolResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::TempDir;
+    use crate::test_utils::{TempDir, link_fake_bin};
     use std::fs;
     use std::path::PathBuf;
     use std::sync::{Mutex, PoisonError};
@@ -1694,24 +1694,22 @@ test('works', () => {
         assert!(result.is_skipped());
     }
 
-    /// Install a fake `jscpd` binary that writes `report_body` (when non-empty)
-    /// to the `--output` dir, mirroring how the real jscpd emits its JSON file.
+    /// Install a fake `jscpd` via a committed, exec-only fixture (never written
+    /// during the test, so it can't hit the write-then-exec ETXTBSY race — #59).
+    /// When `report_body` is non-empty the `jscpd-emit-report` fixture copies it
+    /// from a plain data file (`jscpd-report-src.json`, read via cwd = project
+    /// root) into the `--output` dir, mirroring how real jscpd emits its JSON.
+    /// Empty body uses `jscpd-noop`, which exits 0 without writing a report.
     fn jscpd_project_with_fake_bin(report_body: &str) -> (TempDir, ProjectInfo) {
-        use std::os::unix::fs::PermissionsExt;
         let tmp = TempDir::new("jscpd-gate");
         fs::write(tmp.join("package.json"), "{}").unwrap();
-        let bin_dir = tmp.join("node_modules/.bin");
-        fs::create_dir_all(&bin_dir).unwrap();
-        let bin = bin_dir.join("jscpd");
-        let script = if report_body.is_empty() {
-            "#!/bin/sh\nexit 0\n".to_owned()
+        let fixture = if report_body.is_empty() {
+            "jscpd-noop"
         } else {
-            format!(
-                "#!/bin/sh\nout=\"\"\nwhile [ $# -gt 0 ]; do\n  if [ \"$1\" = \"--output\" ]; then out=\"$2\"; fi\n  shift\ndone\nmkdir -p \"$out\"\ncat > \"$out/jscpd-report.json\" <<'EOF'\n{report_body}\nEOF\n"
-            )
+            fs::write(tmp.join("jscpd-report-src.json"), report_body).unwrap();
+            "jscpd-emit-report"
         };
-        fs::write(&bin, script).unwrap();
-        fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        link_fake_bin(&tmp, "jscpd", fixture);
         let project = ProjectInfo {
             root: tmp.to_path_buf(),
             has_package_json: true,

--- a/tests/fixtures/jscpd-emit-report
+++ b/tests/fixtures/jscpd-emit-report
@@ -1,0 +1,8 @@
+#!/bin/sh
+out=""
+while [ $# -gt 0 ]; do
+  if [ "$1" = "--output" ]; then out="$2"; fi
+  shift
+done
+mkdir -p "$out"
+cp jscpd-report-src.json "$out/jscpd-report.json"

--- a/tests/fixtures/jscpd-noop
+++ b/tests/fixtures/jscpd-noop
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/tests/fixtures/knip-emit
+++ b/tests/fixtures/knip-emit
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo 'emit' > out.js
+exit 1

--- a/tests/fixtures/knip-unused-export
+++ b/tests/fixtures/knip-unused-export
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo 'Unused export' >&2
+exit 1


### PR DESCRIPTION
## 概要と理由

llvm-cov 計装下の `cargo test` 並列実行で、fake binary を「書いて → exec」するゲートテストが ETXTBSY (os error 26) で flaky に落ちていた。exec 対象をテスト中に書かない構造へ変え、レースを根本から除去する。

## 変更点

- `test_utils::link_fake_bin` を追加: コミット済み exec 専用 fixture を `node_modules/.bin` へ symlink。テスト中に exec 対象を一切書かないため、並列 fork が writable fd を継承できずレースが成立しない
- knip テスト (main.rs) の `fs::write`+chmod を `link_fake_bin` 呼び出しへ置換、ローカル helper を削除
- jscpd テスト (tools.rs) を同方式へ移行。パラメータ化された report は `jscpd-emit-report` fixture が data ファイル `jscpd-report-src.json` (read 専用) からコピーする形で再現
- fixture を追加: `knip-unused-export` / `knip-emit` / `jscpd-noop` / `jscpd-emit-report` (mode 100755)

## 対象範囲

- **含まない**: 本番コード (`run_command_with_label` 等) は無改変。fail-open 仕様 (spawn 不能 → skipped) も不変

## 設計判断

- 本番側 errno 26 リトライ案は却下。レースは「別スレッドの fork が書き込み直後ファイルの writable fd を継承」して起きるため exec 側リトライでは根因に届かず、本番を汚す。テスト側の構造的除去 (exec 対象を書かない) を採用
- jscpd は fake binary がパラメータ化されているため単一静的 fixture 不可。exec 対象 (静的) と report 内容 (data ファイル) を分離して解決

## テスト方法

1. `cargo test` → 231 tests pass
2. `cargo llvm-cov --no-report test` を 2 回連続実行 → ETXTBSY 0 件 / failure 0 件

## 関連

- Closes #59

https://claude.ai/code/session_01W5fxUpCLQVQQtwJh2wTXFm