### PR TITLE
style(clippy): pedantic 機械整形 21件を適用

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -112,8 +112,7 @@ pub fn render(entries: &[AuditEntry]) -> String {
 pub fn now_rfc3339() -> String {
     let secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_secs());
     format_rfc3339(secs)
 }
 

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_MIN_LINES: usize = 5;
 /// Default number of clone groups that triggers a block (DRY rule of three).
 pub const DEFAULT_BLOCK_THRESHOLD: usize = 3;
 
-/// ESTree node types whose identifier/literal *content* is normalized away when
+/// `ESTree` node types whose identifier/literal *content* is normalized away when
 /// computing the Type 2 (structural) key, so renamed identifiers and differing
 /// literals hash equal. Gated by node type — not key name — so structural fields
 /// that merely share a name (e.g. `Property.value`) are never blanked.
@@ -39,7 +39,7 @@ pub struct CloneInstance {
 
 /// A set of structurally identical subtrees occurring in 2+ locations.
 pub struct CloneGroup {
-    /// Occurrences, sorted by (path, start_line). Length >= 2.
+    /// Occurrences, sorted by (path, `start_line`). Length >= 2.
     pub instances: Vec<CloneInstance>,
     /// AST node count of the duplicated subtree.
     pub node_count: usize,
@@ -50,7 +50,7 @@ pub struct CloneGroup {
 }
 
 pub struct CloneResult {
-    /// Clone groups, sorted by node_count descending then first path ascending.
+    /// Clone groups, sorted by `node_count` descending then first path ascending.
     pub groups: Vec<CloneGroup>,
 }
 
@@ -66,7 +66,7 @@ struct Candidate {
     end_line: usize,
 }
 
-/// Canonical string pair plus node count produced for a serde_json value.
+/// Canonical string pair plus node count produced for a `serde_json` value.
 struct Rendered {
     named: String,
     blank: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,8 +137,7 @@ impl GatesConfig {
                 }
                 None => {
                     eprintln!(
-                        "gates: ignoring non-boolean value for gate '{}' in {}",
-                        k, TOOLS_CONFIG_FILE
+                        "gates: ignoring non-boolean value for gate '{k}' in {TOOLS_CONFIG_FILE}"
                     );
                 }
             }

--- a/src/hook_exit.rs
+++ b/src/hook_exit.rs
@@ -1,5 +1,5 @@
 //! Process exit codes per ADR-0066 Group 3 (Hook tool) convention, shared with
-//! the role-pair `guardrails` (PreToolUse). gates is the PostToolUse half, so
+//! the role-pair `guardrails` (`PreToolUse`). gates is the `PostToolUse` half, so
 //! its decision surface differs: a blocking decision is emitted as stdout
 //! `{"decision":"block"}` + exit 0 (the OUTCOME constraint and issue #18), not
 //! as a real exit 2. This enum encodes the Group 3 semantics at the type level

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
     let config = config::GatesConfig::load(project_dir);
 
     if should_show_hint(project_dir, &config) {
-        eprintln!("{}", CONFIG_HINT);
+        eprintln!("{CONFIG_HINT}");
     }
 
     let project = project::ProjectInfo::detect(project_dir);
@@ -241,7 +241,7 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
         .map(|(name, handle)| match handle.join() {
             Ok(result) => result,
             Err(e) => {
-                eprintln!("gates: {} thread panicked: {:?}", name, e);
+                eprintln!("gates: {name} thread panicked: {e:?}");
                 tools::ToolResult::skipped(name)
             }
         })
@@ -296,7 +296,7 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
         match handle.join() {
             Ok(script_results) => results.extend(script_results),
             Err(e) => {
-                eprintln!("gates: script gates thread panicked: {:?}", e);
+                eprintln!("gates: script gates thread panicked: {e:?}");
                 for name in &script_gate_names {
                     results.push(tools::ToolResult::skipped(name));
                 }
@@ -442,7 +442,7 @@ fn format_show_output(entries: &[audit::AuditEntry], json: bool) -> Option<Strin
 
 /// Write one line to stdout, returning an exit code. A closed downstream pipe
 /// (`gates show | head`) exits 0 instead of panicking the way `println!` does;
-/// any other write error maps to EX_IOERR.
+/// any other write error maps to `EX_IOERR`.
 fn write_stdout(s: &str) -> i32 {
     match writeln!(io::stdout(), "{s}") {
         Ok(()) => 0,
@@ -485,7 +485,7 @@ fn main() {
     // `gates post-bash [dir]`: PostToolUse Bash trigger (issue #17). Runs gates
     // only when the fileset changed since the last run; otherwise fast-exits.
     if args.get(1).map(String::as_str) == Some("post-bash") {
-        let dir = args.get(2).map(String::as_str).unwrap_or(".");
+        let dir = args.get(2).map_or(".", String::as_str);
         let project_dir = Path::new(dir);
         if !project_dir.is_dir() {
             eprintln!("gates: not a directory: {}", project_dir.display());
@@ -502,7 +502,7 @@ fn main() {
         process::exit(ex_usage());
     }
 
-    let dir = args.get(1).map(String::as_str).unwrap_or(".");
+    let dir = args.get(1).map_or(".", String::as_str);
     let project_dir = Path::new(dir);
     if !project_dir.is_dir() {
         eprintln!("gates: not a directory: {}", project_dir.display());
@@ -514,7 +514,7 @@ fn main() {
     }
 }
 
-/// PostToolUse Bash entry (issue #17): run gates only when the gated fileset
+/// `PostToolUse` Bash entry (issue #17): run gates only when the gated fileset
 /// changed since the last recorded snapshot. A matching stored digest means no
 /// gated file changed, so the gates are skipped (fast-exit). A missing snapshot
 /// dir, a missing/corrupt stored digest, or a mismatch all fall through to a full

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -4,8 +4,7 @@ use std::path::{Path, PathBuf};
 
 fn is_executable(path: &Path) -> bool {
     path.metadata()
-        .map(|m| m.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false)
+        .is_ok_and(|m| m.permissions().mode() & 0o111 != 0)
 }
 
 pub fn resolve_bin(name: &str, start: &Path) -> PathBuf {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,4 +1,4 @@
-//! Filesystem-delta snapshot for the PostToolUse Bash trigger (issue #17).
+//! Filesystem-delta snapshot for the `PostToolUse` Bash trigger (issue #17).
 //!
 //! Computes a ctime+size digest over the target fileset (FR-001), and reads /
 //! writes the per-project digest state file fail-open (FR-002..FR-004). Bash
@@ -68,7 +68,7 @@ fn collect_targets(dir: &Path, root: &Path, out: &mut Vec<(String, PathBuf)>) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+        let is_dir = entry.file_type().is_ok_and(|ft| ft.is_dir());
         if is_dir {
             let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
             if !EXCLUDED_DIRS.contains(&name) {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -901,7 +901,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::{Mutex, PoisonError};
 
-    /// run_jscpd derives its temp output dir from the process PID, so the three
+    /// `run_jscpd` derives its temp output dir from the process PID, so the three
     /// end-to-end tests below share one dir. Serialize them so one test's report
     /// is never read (or wiped) by another running concurrently.
     static JSCPD_RUN_LOCK: Mutex<()> = Mutex::new(());
@@ -1459,7 +1459,7 @@ mod tests {
         fs::create_dir_all(tmp.join("src")).unwrap();
         fs::write(
             tmp.join("src/example.test.ts"),
-            r#"
+            r"
 import { describe, test, expect } from 'vitest';
 describe('math', () => {
     test('adds two numbers correctly', () => {
@@ -1467,7 +1467,7 @@ describe('math', () => {
         expect(result).toBe(3);
     });
 });
-"#,
+",
         )
         .unwrap();
         let project = ProjectInfo {
@@ -1489,12 +1489,12 @@ describe('math', () => {
         fs::write(tmp.join("package.json"), "{}").unwrap();
         fs::write(
             tmp.join("bad.test.ts"),
-            r#"
+            r"
 import { test, expect } from 'vitest';
 test('works', () => {
     expect(true).toBe(true);
 });
-"#,
+",
         )
         .unwrap();
         let project = ProjectInfo {


### PR DESCRIPTION
## 概要

敵対的レビュー (#30) で検出した clippy pedantic 33件のうち、無挙動変更でコードベースの既存スタイルに合わせる機械整形のみを `cargo clippy --fix` で適用する。

## 変更内訳 (21件 / 8ファイル)

| lint | 件数 | 内容 |
| --- | --- | --- |
| doc_markdown | 10 | doc コメント内の識別子をバッククォート化 |
| uninlined_format_args | 4 | `format!` 引数のインライン化 (`{:?}` → `{e:?}` 等) |
| map_unwrap_or | 5 | `map(f).unwrap_or` → `map_or` / `is_ok_and` |
| needless_raw_string_hashes | 2 | 不要な raw string ハッシュ除去 |

対象ファイル: main / clone / tools / config / snapshot / audit / hook_exit / resolve

## 検証

- deny-set clippy (プロジェクト既定): warning / error なし
- 対象 pedantic 4 lint 残数: 0
- `cargo test --workspace`: 231 passed / 0 failed
- 振る舞い不変

## 除外したもの

判断を要する pedantic は機械整形では誤りうるため除外。

- `float_cmp` / `cast_precision_loss` / `single_match_else` / `if_not_else` / `manual_let_else` / `duration_suboptimal_units`: スタイル/数値判断
- `case_sensitive_file_extension_comparisons` (audit.rs): 比較値が内部生成のため実害なし、`#[allow]` + 理由付記が妥当
- `too_many_lines` (run_with_overrides): #63 のリファクタで解消

https://claude.ai/code/session_01XT5y4k8Ky53WSETWaJsBbv