### PR TITLE
refactor(reporter): BLOCKED ヘッダ/フッタ/文言の二重生成を reporter へ抽出

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,7 @@ fn should_show_hint(project_dir: &Path, config: &config::GatesConfig) -> bool {
 }
 
 fn format_failures(failures: &[&tools::ToolResult]) -> String {
-    let mut lines = vec![String::new()];
-    lines.push(color::bold_red(&format!(
-        "Gates {}",
-        reporter::HEADER_SEPARATOR
-    )));
+    let mut lines = vec![String::new(), reporter::blocked_header()];
 
     for (i, f) in failures.iter().enumerate() {
         if i > 0 {
@@ -85,12 +81,7 @@ fn format_failures(failures: &[&tools::ToolResult]) -> String {
         }
     }
 
-    lines.push(color::bold_red(reporter::FOOTER_SEPARATOR));
-    lines.push(color::bold_red(&format!(
-        "BLOCKED: {} gate{} failed. Fix the source code and retry. Do not circumvent this check.",
-        failures.len(),
-        if failures.len() == 1 { "" } else { "s" }
-    )));
+    lines.push(reporter::blocked_footer(failures.len()));
 
     lines.join("\n")
 }
@@ -545,16 +536,14 @@ mod tests {
     }
 
     fn expected_block(gate_lines: &[&str], count: usize) -> String {
-        let header = format!("Gates {}", reporter::HEADER_SEPARATOR);
-        let blocked = format!(
-            "BLOCKED: {} gate{} failed. Fix the source code and retry. Do not circumvent this check.",
-            count,
-            if count == 1 { "" } else { "s" }
-        );
+        // Reference the same skeleton the production path renders, stripped to
+        // match the strip_ansi'd actual. Pins format_failures to reporter's
+        // byte contract rather than re-declaring the wording here.
+        let header = color::strip_ansi(&reporter::blocked_header());
+        let footer = color::strip_ansi(&reporter::blocked_footer(count));
         let mut lines = vec!["", header.as_str()];
         lines.extend_from_slice(gate_lines);
-        lines.push(reporter::FOOTER_SEPARATOR);
-        lines.push(&blocked);
+        lines.push(&footer);
         lines.join("\n")
     }
 

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -1,10 +1,36 @@
 use crate::color;
 use crate::tools::ToolResult;
 
-// Match guardrails separator lengths (header + "Gates " = 50, footer = 50)
-pub(crate) const HEADER_SEPARATOR: &str = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
-pub(crate) const FOOTER_SEPARATOR: &str = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+// Match guardrails separator lengths (header + "Gates " = 50, footer = 50).
+// Private: the BLOCKED skeleton (blocked_header/blocked_footer) is the only
+// cross-module surface, so the raw separators stay internal to reporter.
+const HEADER_SEPARATOR: &str = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+const FOOTER_SEPARATOR: &str = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
 const MAX_PREVIEW_LINES: usize = 3;
+
+/// The bold-red `Gates ━━━` header line opening a BLOCKED block. Owned here so
+/// the stderr summary and the AI-facing failure block (`main::format_failures`)
+/// render a byte-identical header from one source.
+pub(crate) fn blocked_header() -> String {
+    color::bold_red(&format!("Gates {HEADER_SEPARATOR}"))
+}
+
+/// The two-line BLOCKED footer: the separator line followed by the BLOCKED
+/// message. Owns the singular/plural branch and the exact wording so a wording
+/// or separator change lands in one place. Returned as a single `\n`-joined
+/// string; pushing it into a line vec and `join("\n")`-ing yields the same bytes
+/// as two separate pushes.
+pub(crate) fn blocked_footer(n_failures: usize) -> String {
+    format!(
+        "{}\n{}",
+        color::bold_red(FOOTER_SEPARATOR),
+        color::bold_red(&format!(
+            "BLOCKED: {} gate{} failed. Fix the source code and retry. Do not circumvent this check.",
+            n_failures,
+            if n_failures == 1 { "" } else { "s" }
+        ))
+    )
+}
 
 pub fn format_summary(results: &[ToolResult]) -> String {
     let ran: Vec<_> = results.iter().filter(|r| !r.is_skipped()).collect();
@@ -26,22 +52,14 @@ pub fn format_summary(results: &[ToolResult]) -> String {
         return lines.join("\n");
     }
 
-    let mut lines = vec![
-        String::new(),
-        color::bold_red(&format!("Gates {HEADER_SEPARATOR}")),
-    ];
+    let mut lines = vec![String::new(), blocked_header()];
 
     for f in &failures {
         lines.push(color::red(&format!("  \u{2717} {}", f.name)));
         push_preview(&mut lines, f.output(), color::red);
     }
 
-    lines.push(color::bold_red(FOOTER_SEPARATOR));
-    lines.push(color::bold_red(&format!(
-        "BLOCKED: {} gate{} failed. Fix the source code and retry. Do not circumvent this check.",
-        failures.len(),
-        if failures.len() == 1 { "" } else { "s" }
-    )));
+    lines.push(blocked_footer(failures.len()));
 
     append_advisories(&mut lines, &warnings);
 


### PR DESCRIPTION
## 概要

`format_failures` (main) と `format_summary` (reporter) が独立に二重生成していた BLOCKED 表示骨格 (ヘッダ/フッタ/文言) を `reporter` の2関数に集約する。文言またはセパレータの変更が3箇所同時編集を強制していた DRY 違反 (同一知識・1変更が全インスタンスを強制) を解消し、クロスモジュールの文字列契約を reporter 1モジュールに収める。

## 変更点

- `reporter::blocked_header()` を追加: bold-red `Gates ━━━` ヘッダ行を所有
- `reporter::blocked_footer(n)` を追加: セパレータ + 単数/複数分岐 + BLOCKED 文言の2行を所有
- `format_failures` / `format_summary` の両呼び出し側をこれらの呼び出しに置換。失敗ごとの本体 (AI 向け全行 vs 人間向け3行プレビュー) は正当に異なるため各関数に残す
- `expected_block` テストヘルパを `strip_ansi` 経由で抽出関数を参照するよう変更し、文言の再宣言を排除
- `HEADER_SEPARATOR` / `FOOTER_SEPARATOR` を外部参照消失に伴い `pub(crate)` → private に縮小

## スコープ

- **対象外**: 両関数本体の統合 (出力形態が AI 向け全行 / 人間向けプレビューで正当に異なるため非統合)。失敗ごとの `✗ {name}` 行も設計上わざと重複維持

## 設計判断

- `blocked_footer(n)` は footer セパレータ行 + BLOCKED 行を `\n` 区切りの1文字列で返す。呼び出し側が push → `join("\n")` する形は、元の2回 push と同一バイト列 (埋め込み改行と join の改行が一致)。出力バイト列は不変
- 検証は reporter T-611系の独立リテラル assertion (BLOCKED 文言直書き・セパレータ長) を pin に据える。共有関数のバイトが reporter テストで保証され、`format_failures` にも transitively 効く

## テスト手順

1. `cargo test` を実行
2. 全237テストが green (reporter 15件 + main failure フォーマットテスト含む)
3. `cargo clippy` で warning なし

## 関連

- Closes #65
- Ref: #30

https://claude.ai/code/session_01RU3XaqdYucCZiFw3294EuG
