### PR TITLE
1771行 god module をランナー基盤とゲートアダプタに凝集分割

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod hook_exit;
 mod project;
 mod reporter;
 mod resolve;
+mod runner;
 mod sanitize;
 mod snapshot;
 #[cfg(test)]
@@ -53,7 +54,7 @@ fn should_show_hint(project_dir: &Path, config: &config::GatesConfig) -> bool {
     project_dir.join(".claude").is_dir()
 }
 
-fn format_failures(failures: &[&tools::ToolResult]) -> String {
+fn format_failures(failures: &[&runner::ToolResult]) -> String {
     let mut lines = vec![String::new(), reporter::blocked_header()];
 
     for (i, f) in failures.iter().enumerate() {
@@ -109,18 +110,18 @@ fn record_snapshot(project_root: &Path, overrides: &tools::EnvOverrides) {
 /// `skipped` if the thread panics.
 type GateTask = (
     Vec<&'static str>,
-    thread::JoinHandle<Vec<tools::ToolResult>>,
+    thread::JoinHandle<Vec<runner::ToolResult>>,
 );
 
 /// Join one gate thread into `results`. Owns the panic→`skipped` mapping in one
 /// place: a panicked gate degrades to a `skipped` result per fallback name
 /// rather than aborting the hook (OUTCOME fail-open constraint).
-fn join_into(results: &mut Vec<tools::ToolResult>, (fallback, handle): GateTask) {
+fn join_into(results: &mut Vec<runner::ToolResult>, (fallback, handle): GateTask) {
     match handle.join() {
         Ok(gate_results) => results.extend(gate_results),
         Err(e) => {
             eprintln!("gates: {} thread panicked: {e:?}", fallback.join("+"));
-            results.extend(fallback.into_iter().map(tools::ToolResult::skipped));
+            results.extend(fallback.into_iter().map(runner::ToolResult::skipped));
         }
     }
 }
@@ -254,7 +255,7 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
         return None;
     }
 
-    let mut results: Vec<tools::ToolResult> = Vec::new();
+    let mut results: Vec<runner::ToolResult> = Vec::new();
     for task in tasks {
         join_into(&mut results, task);
     }
@@ -300,7 +301,7 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
 /// reported to stderr but never propagated into the hook control flow.
 fn record_audit(
     project_dir: &Path,
-    failures: &[&tools::ToolResult],
+    failures: &[&runner::ToolResult],
     overrides: &tools::EnvOverrides,
 ) {
     let Some(dir) = overrides.audit_dir.as_deref() else {
@@ -320,7 +321,7 @@ fn record_audit(
     }
 }
 
-fn warn_missing_tools(results: &[tools::ToolResult], project: &project::ProjectInfo) {
+fn warn_missing_tools(results: &[runner::ToolResult], project: &project::ProjectInfo) {
     for gate in tools::GATES {
         if !(gate.condition)(project) {
             continue;
@@ -516,14 +517,14 @@ mod tests {
     // data-driven mapping this refactor introduced.
     #[test]
     fn join_into_maps_panic_to_skipped_per_fallback_name() {
-        let mut results: Vec<tools::ToolResult> = Vec::new();
+        let mut results: Vec<runner::ToolResult> = Vec::new();
         let task: GateTask = (
             vec!["circular", "coupling"],
             thread::spawn(|| panic!("gate thread blew up")),
         );
         join_into(&mut results, task);
         assert_eq!(results.len(), 2);
-        assert!(results.iter().all(tools::ToolResult::is_skipped));
+        assert!(results.iter().all(runner::ToolResult::is_skipped));
         assert_eq!(results[0].name, "circular");
         assert_eq!(results[1].name, "coupling");
     }
@@ -760,10 +761,10 @@ mod tests {
 
     #[test]
     fn format_single_failure_with_output() {
-        let r = tools::ToolResult {
+        let r = runner::ToolResult {
             name: "knip",
             hint: "Remove unused exports and dependencies.",
-            outcome: tools::GateOutcome::Failed("Unused export: src/foo.ts".into()),
+            outcome: runner::GateOutcome::Failed("Unused export: src/foo.ts".into()),
         };
         let result = color::strip_ansi(&format_failures(&[&r]));
         assert_eq!(
@@ -782,10 +783,10 @@ mod tests {
 
     #[test]
     fn format_single_failure_without_output() {
-        let r = tools::ToolResult {
+        let r = runner::ToolResult {
             name: "knip",
             hint: "Remove unused exports and dependencies.",
-            outcome: tools::GateOutcome::Failed(String::new()),
+            outcome: runner::GateOutcome::Failed(String::new()),
         };
         let result = color::strip_ansi(&format_failures(&[&r]));
         assert_eq!(
@@ -802,10 +803,10 @@ mod tests {
 
     #[test]
     fn format_single_failure_fallback_hint() {
-        let r = tools::ToolResult {
+        let r = runner::ToolResult {
             name: "custom",
             hint: "",
-            outcome: tools::GateOutcome::Failed("error output".into()),
+            outcome: runner::GateOutcome::Failed("error output".into()),
         };
         let result = color::strip_ansi(&format_failures(&[&r]));
         assert_eq!(
@@ -824,15 +825,15 @@ mod tests {
 
     #[test]
     fn format_multiple_failures() {
-        let r1 = tools::ToolResult {
+        let r1 = runner::ToolResult {
             name: "knip",
             hint: "Remove unused exports and dependencies.",
-            outcome: tools::GateOutcome::Failed("Unused export".into()),
+            outcome: runner::GateOutcome::Failed("Unused export".into()),
         };
-        let r2 = tools::ToolResult {
+        let r2 = runner::ToolResult {
             name: "tsgo",
             hint: "Fix type errors.",
-            outcome: tools::GateOutcome::Failed("TS2345: type error".into()),
+            outcome: runner::GateOutcome::Failed("TS2345: type error".into()),
         };
         let result = color::strip_ansi(&format_failures(&[&r1, &r2]));
         assert_eq!(
@@ -856,15 +857,15 @@ mod tests {
 
     #[test]
     fn format_multiple_failures_without_output() {
-        let r1 = tools::ToolResult {
+        let r1 = runner::ToolResult {
             name: "knip",
             hint: "Remove unused exports and dependencies.",
-            outcome: tools::GateOutcome::Failed(String::new()),
+            outcome: runner::GateOutcome::Failed(String::new()),
         };
-        let r2 = tools::ToolResult {
+        let r2 = runner::ToolResult {
             name: "tsgo",
             hint: "Fix type errors.",
-            outcome: tools::GateOutcome::Failed(String::new()),
+            outcome: runner::GateOutcome::Failed(String::new()),
         };
         let result = color::strip_ansi(&format_failures(&[&r1, &r2]));
         assert_eq!(
@@ -884,15 +885,15 @@ mod tests {
 
     #[test]
     fn format_multiple_failures_mixed_hints() {
-        let r1 = tools::ToolResult {
+        let r1 = runner::ToolResult {
             name: "custom",
             hint: "",
-            outcome: tools::GateOutcome::Failed("error".into()),
+            outcome: runner::GateOutcome::Failed("error".into()),
         };
-        let r2 = tools::ToolResult {
+        let r2 = runner::ToolResult {
             name: "knip",
             hint: "Remove unused exports and dependencies.",
-            outcome: tools::GateOutcome::Failed("Unused export".into()),
+            outcome: runner::GateOutcome::Failed("Unused export".into()),
         };
         let result = color::strip_ansi(&format_failures(&[&r1, &r2]));
         assert_eq!(

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -1,5 +1,5 @@
 use crate::color;
-use crate::tools::ToolResult;
+use crate::runner::ToolResult;
 
 // Match guardrails separator lengths (header + "Gates " = 50, footer = 50).
 // Private: the BLOCKED skeleton (blocked_header/blocked_footer) is the only
@@ -106,7 +106,7 @@ fn push_preview(lines: &mut Vec<String>, output: &str, colorize: fn(&str) -> Str
 mod tests {
     use super::*;
     use crate::color::strip_ansi;
-    use crate::tools::GateOutcome;
+    use crate::runner::GateOutcome;
 
     fn passed(name: &'static str) -> ToolResult {
         ToolResult {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,0 +1,269 @@
+use crate::sanitize;
+use std::io;
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+pub(crate) const GATE_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_OUTPUT_LINES: usize = 50;
+
+#[derive(Debug)]
+pub enum GateOutcome {
+    Passed,
+    Failed(String),
+    Skipped,
+    /// Advisory failure: reported to the human via stderr but not promoted to a
+    /// block decision, so the AI is not forced to act. Used by warn-level gates.
+    Warned(String),
+}
+
+#[derive(Debug)]
+pub struct ToolResult {
+    pub name: &'static str,
+    pub hint: &'static str,
+    pub outcome: GateOutcome,
+}
+
+impl ToolResult {
+    pub fn skipped(name: &'static str) -> Self {
+        Self {
+            name,
+            hint: "",
+            outcome: GateOutcome::Skipped,
+        }
+    }
+
+    pub fn passed(name: &'static str) -> Self {
+        Self {
+            name,
+            hint: "",
+            outcome: GateOutcome::Passed,
+        }
+    }
+
+    /// Build a Failed result whose output is truncated to `MAX_OUTPUT_LINES`,
+    /// the shared truncation policy for embedded gates.
+    ///
+    /// `run_command_with_label` does not use this: external command output also
+    /// needs `sanitize` + `trim` and may resolve to `Passed`, so it assembles
+    /// its outcome inline.
+    pub fn failed(name: &'static str, hint: &'static str, text: &str) -> Self {
+        Self {
+            name,
+            hint,
+            outcome: GateOutcome::Failed(sanitize::tail_lines(text, MAX_OUTPUT_LINES)),
+        }
+    }
+
+    /// Build a Warned result: the advisory counterpart of `failed`, sharing the
+    /// same truncation policy. Reported to the human but never blocks the AI.
+    pub fn warned(name: &'static str, hint: &'static str, text: &str) -> Self {
+        Self {
+            name,
+            hint,
+            outcome: GateOutcome::Warned(sanitize::tail_lines(text, MAX_OUTPUT_LINES)),
+        }
+    }
+
+    pub fn is_failure(&self) -> bool {
+        matches!(self.outcome, GateOutcome::Failed(_))
+    }
+
+    pub fn is_warning(&self) -> bool {
+        matches!(self.outcome, GateOutcome::Warned(_))
+    }
+
+    pub fn is_skipped(&self) -> bool {
+        matches!(self.outcome, GateOutcome::Skipped)
+    }
+
+    pub fn output(&self) -> &str {
+        match &self.outcome {
+            GateOutcome::Failed(s) | GateOutcome::Warned(s) => s,
+            GateOutcome::Passed | GateOutcome::Skipped => "",
+        }
+    }
+}
+
+fn kill_process_group(pid: u32) {
+    if pid == 0 {
+        eprintln!("gates: pid 0, refusing to kill own process group");
+        return;
+    }
+    let Ok(pid_i32) = i32::try_from(pid) else {
+        eprintln!("gates: pid {pid} exceeds i32::MAX, cannot kill process group");
+        return;
+    };
+    let target = format!("-{pid_i32}");
+    let status = Command::new("kill")
+        .args(["-9", &target])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    match status {
+        Ok(s) if !s.success() => {
+            eprintln!("gates: kill exited {s} for process group {pid}");
+        }
+        Err(e) => {
+            eprintln!("gates: failed to kill process group {pid}: {e}");
+        }
+        _ => {}
+    }
+}
+
+pub(crate) fn run_command(name: &'static str, cmd: Command, timeout: Duration) -> ToolResult {
+    run_command_with_label(name, cmd, timeout, None)
+}
+
+pub(crate) fn run_command_with_label(
+    name: &'static str,
+    mut cmd: Command,
+    timeout: Duration,
+    label: Option<&str>,
+) -> ToolResult {
+    cmd.process_group(0);
+
+    let child = match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            match e.kind() {
+                io::ErrorKind::NotFound => {}
+                io::ErrorKind::PermissionDenied => {
+                    eprintln!("gates: {name} binary found but not executable: {e}");
+                }
+                _ => {
+                    eprintln!("gates: {name} spawn error: {e}");
+                }
+            }
+            return ToolResult::skipped(name);
+        }
+    };
+
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        let result = child.wait_with_output();
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let combined = if stderr.is_empty() {
+                stdout.into_owned()
+            } else if stdout.is_empty() {
+                stderr.into_owned()
+            } else {
+                format!("{stdout}\n{stderr}")
+            };
+            let sanitized = sanitize::sanitize(&combined);
+            let truncated = sanitize::tail_lines(&sanitized, MAX_OUTPUT_LINES);
+            let text = truncated.trim().to_owned();
+
+            let outcome = if output.status.success() {
+                GateOutcome::Passed
+            } else {
+                GateOutcome::Failed(text)
+            };
+            ToolResult {
+                name,
+                hint: "",
+                outcome,
+            }
+        }
+        Ok(Err(e)) => {
+            eprintln!("gates: {name} output read error: {e}");
+            ToolResult::skipped(name)
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            if let Some(l) = label {
+                eprintln!(
+                    "gates: {} timed out after {}s (cmd: {})",
+                    name,
+                    timeout.as_secs(),
+                    l
+                );
+            } else {
+                eprintln!("gates: {} timed out after {}s", name, timeout.as_secs());
+            }
+            kill_process_group(pid);
+            let _ = rx.recv_timeout(Duration::from_secs(2));
+            ToolResult::skipped(name)
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            eprintln!("gates: {name} wait thread disconnected");
+            ToolResult::skipped(name)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skipped_result() {
+        let r = ToolResult::skipped("test");
+        assert!(r.is_skipped());
+        assert!(!r.is_failure());
+        assert!(r.output().is_empty());
+    }
+
+    // T-601: a Warned outcome is not a failure (stays out of the block decision).
+    #[test]
+    fn warned_is_not_failure() {
+        let r = ToolResult::warned("jscpd", "hint", "dup");
+        assert!(!r.is_failure());
+    }
+
+    // T-602: a Warned outcome counts as ran, not skipped.
+    #[test]
+    fn warned_is_not_skipped() {
+        let r = ToolResult::warned("jscpd", "hint", "dup");
+        assert!(!r.is_skipped());
+        assert!(r.is_warning());
+    }
+
+    // T-603: a Warned outcome exposes its text via output().
+    #[test]
+    fn warned_exposes_output() {
+        let r = ToolResult::warned("jscpd", "hint", "duplication detail");
+        assert_eq!(r.output(), "duplication detail");
+    }
+
+    #[test]
+    fn command_success() {
+        let mut cmd = Command::new("echo");
+        cmd.arg("hello");
+        let result = run_command("echo-test", cmd, Duration::from_secs(5));
+        assert!(matches!(result.outcome, GateOutcome::Passed));
+    }
+
+    #[test]
+    fn command_failure() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "echo fail >&2; exit 1"]);
+        let result = run_command("fail-test", cmd, Duration::from_secs(5));
+        assert!(result.is_failure());
+        assert!(result.output().contains("fail"));
+    }
+
+    #[test]
+    fn timeout_returns_skipped() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("120");
+        let result = run_command("sleep-test", cmd, Duration::from_millis(200));
+        assert!(result.is_skipped());
+    }
+
+    #[test]
+    fn spawn_error_returns_skipped() {
+        let cmd = Command::new("nonexistent-binary-99999");
+        let result = run_command("missing", cmd, Duration::from_secs(5));
+        assert!(result.is_skipped());
+    }
+}

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -5,101 +5,17 @@ use crate::coupling;
 use crate::depgraph;
 use crate::project::ProjectInfo;
 use crate::resolve;
-use crate::sanitize;
+use crate::runner::{GATE_TIMEOUT, ToolResult, run_command, run_command_with_label};
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::io;
 use std::iter;
-use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process;
-use std::process::{Command, Stdio};
-use std::sync::mpsc;
+use std::process::Command;
 use std::thread;
-use std::time::Duration;
-
-const GATE_TIMEOUT: Duration = Duration::from_secs(60);
-const MAX_OUTPUT_LINES: usize = 50;
-
-#[derive(Debug)]
-pub enum GateOutcome {
-    Passed,
-    Failed(String),
-    Skipped,
-    /// Advisory failure: reported to the human via stderr but not promoted to a
-    /// block decision, so the AI is not forced to act. Used by warn-level gates.
-    Warned(String),
-}
-
-#[derive(Debug)]
-pub struct ToolResult {
-    pub name: &'static str,
-    pub hint: &'static str,
-    pub outcome: GateOutcome,
-}
-
-impl ToolResult {
-    pub fn skipped(name: &'static str) -> Self {
-        Self {
-            name,
-            hint: "",
-            outcome: GateOutcome::Skipped,
-        }
-    }
-
-    pub fn passed(name: &'static str) -> Self {
-        Self {
-            name,
-            hint: "",
-            outcome: GateOutcome::Passed,
-        }
-    }
-
-    /// Build a Failed result whose output is truncated to `MAX_OUTPUT_LINES`,
-    /// the shared truncation policy for embedded gates.
-    ///
-    /// `run_command_with_label` does not use this: external command output also
-    /// needs `sanitize` + `trim` and may resolve to `Passed`, so it assembles
-    /// its outcome inline.
-    pub fn failed(name: &'static str, hint: &'static str, text: &str) -> Self {
-        Self {
-            name,
-            hint,
-            outcome: GateOutcome::Failed(sanitize::tail_lines(text, MAX_OUTPUT_LINES)),
-        }
-    }
-
-    /// Build a Warned result: the advisory counterpart of `failed`, sharing the
-    /// same truncation policy. Reported to the human but never blocks the AI.
-    pub fn warned(name: &'static str, hint: &'static str, text: &str) -> Self {
-        Self {
-            name,
-            hint,
-            outcome: GateOutcome::Warned(sanitize::tail_lines(text, MAX_OUTPUT_LINES)),
-        }
-    }
-
-    pub fn is_failure(&self) -> bool {
-        matches!(self.outcome, GateOutcome::Failed(_))
-    }
-
-    pub fn is_warning(&self) -> bool {
-        matches!(self.outcome, GateOutcome::Warned(_))
-    }
-
-    pub fn is_skipped(&self) -> bool {
-        matches!(self.outcome, GateOutcome::Skipped)
-    }
-
-    pub fn output(&self) -> &str {
-        match &self.outcome {
-            GateOutcome::Failed(s) | GateOutcome::Warned(s) => s,
-            GateOutcome::Passed | GateOutcome::Skipped => "",
-        }
-    }
-}
 
 pub struct GateDefinition {
     pub name: &'static str,
@@ -412,120 +328,6 @@ pub fn gate_by_name(name: &str) -> &'static GateDefinition {
         .iter()
         .find(|g| g.name == name)
         .unwrap_or_else(|| panic!("gate '{name}' not found"))
-}
-
-fn kill_process_group(pid: u32) {
-    if pid == 0 {
-        eprintln!("gates: pid 0, refusing to kill own process group");
-        return;
-    }
-    let Ok(pid_i32) = i32::try_from(pid) else {
-        eprintln!("gates: pid {pid} exceeds i32::MAX, cannot kill process group");
-        return;
-    };
-    let target = format!("-{pid_i32}");
-    let status = Command::new("kill")
-        .args(["-9", &target])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
-    match status {
-        Ok(s) if !s.success() => {
-            eprintln!("gates: kill exited {s} for process group {pid}");
-        }
-        Err(e) => {
-            eprintln!("gates: failed to kill process group {pid}: {e}");
-        }
-        _ => {}
-    }
-}
-
-fn run_command(name: &'static str, cmd: Command, timeout: Duration) -> ToolResult {
-    run_command_with_label(name, cmd, timeout, None)
-}
-
-fn run_command_with_label(
-    name: &'static str,
-    mut cmd: Command,
-    timeout: Duration,
-    label: Option<&str>,
-) -> ToolResult {
-    cmd.process_group(0);
-
-    let child = match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
-        Ok(c) => c,
-        Err(e) => {
-            match e.kind() {
-                io::ErrorKind::NotFound => {}
-                io::ErrorKind::PermissionDenied => {
-                    eprintln!("gates: {name} binary found but not executable: {e}");
-                }
-                _ => {
-                    eprintln!("gates: {name} spawn error: {e}");
-                }
-            }
-            return ToolResult::skipped(name);
-        }
-    };
-
-    let pid = child.id();
-    let (tx, rx) = mpsc::channel();
-
-    thread::spawn(move || {
-        let result = child.wait_with_output();
-        let _ = tx.send(result);
-    });
-
-    match rx.recv_timeout(timeout) {
-        Ok(Ok(output)) => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let combined = if stderr.is_empty() {
-                stdout.into_owned()
-            } else if stdout.is_empty() {
-                stderr.into_owned()
-            } else {
-                format!("{stdout}\n{stderr}")
-            };
-            let sanitized = sanitize::sanitize(&combined);
-            let truncated = sanitize::tail_lines(&sanitized, MAX_OUTPUT_LINES);
-            let text = truncated.trim().to_owned();
-
-            let outcome = if output.status.success() {
-                GateOutcome::Passed
-            } else {
-                GateOutcome::Failed(text)
-            };
-            ToolResult {
-                name,
-                hint: "",
-                outcome,
-            }
-        }
-        Ok(Err(e)) => {
-            eprintln!("gates: {name} output read error: {e}");
-            ToolResult::skipped(name)
-        }
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            if let Some(l) = label {
-                eprintln!(
-                    "gates: {} timed out after {}s (cmd: {})",
-                    name,
-                    timeout.as_secs(),
-                    l
-                );
-            } else {
-                eprintln!("gates: {} timed out after {}s", name, timeout.as_secs());
-            }
-            kill_process_group(pid);
-            let _ = rx.recv_timeout(Duration::from_secs(2));
-            ToolResult::skipped(name)
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            eprintln!("gates: {name} wait thread disconnected");
-            ToolResult::skipped(name)
-        }
-    }
 }
 
 pub fn run_litmus(project: &ProjectInfo) -> ToolResult {
@@ -1067,36 +869,6 @@ mod tests {
     }
 
     #[test]
-    fn skipped_result() {
-        let r = ToolResult::skipped("test");
-        assert!(r.is_skipped());
-        assert!(!r.is_failure());
-        assert!(r.output().is_empty());
-    }
-
-    // T-601: a Warned outcome is not a failure (stays out of the block decision).
-    #[test]
-    fn warned_is_not_failure() {
-        let r = ToolResult::warned("jscpd", "hint", "dup");
-        assert!(!r.is_failure());
-    }
-
-    // T-602: a Warned outcome counts as ran, not skipped.
-    #[test]
-    fn warned_is_not_skipped() {
-        let r = ToolResult::warned("jscpd", "hint", "dup");
-        assert!(!r.is_skipped());
-        assert!(r.is_warning());
-    }
-
-    // T-603: a Warned outcome exposes its text via output().
-    #[test]
-    fn warned_exposes_output() {
-        let r = ToolResult::warned("jscpd", "hint", "duplication detail");
-        assert_eq!(r.output(), "duplication detail");
-    }
-
-    #[test]
     fn gates_skip_when_condition_not_met() {
         for (name, project) in [
             ("knip", test_project(false, false)),
@@ -1505,38 +1277,6 @@ test('works', () => {
         let result = run_litmus(&project);
         assert!(result.is_failure(), "tautological test should fail");
         assert!(result.output().contains("tautological"));
-    }
-
-    #[test]
-    fn command_success() {
-        let mut cmd = Command::new("echo");
-        cmd.arg("hello");
-        let result = run_command("echo-test", cmd, Duration::from_secs(5));
-        assert!(matches!(result.outcome, GateOutcome::Passed));
-    }
-
-    #[test]
-    fn command_failure() {
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "echo fail >&2; exit 1"]);
-        let result = run_command("fail-test", cmd, Duration::from_secs(5));
-        assert!(result.is_failure());
-        assert!(result.output().contains("fail"));
-    }
-
-    #[test]
-    fn timeout_returns_skipped() {
-        let mut cmd = Command::new("sleep");
-        cmd.arg("120");
-        let result = run_command("sleep-test", cmd, Duration::from_millis(200));
-        assert!(result.is_skipped());
-    }
-
-    #[test]
-    fn spawn_error_returns_skipped() {
-        let cmd = Command::new("nonexistent-binary-99999");
-        let result = run_command("missing", cmd, Duration::from_secs(5));
-        assert!(result.is_skipped());
     }
 
     fn clone_project(files: &[(&str, &str)]) -> TempDir {


### PR DESCRIPTION
## 概要
tools.rs (god module) から汎用コマンド実行基盤を新規 src/runner.rs へ逐語移設し、ゲートアダプタと分離する。reporter→tools 依存を切断する。

## 変更点
- runner.rs 新規: GATE_TIMEOUT/MAX_OUTPUT_LINES/GateOutcome/ToolResult/kill_process_group/run_command/run_command_with_label + runner テスト8件
- tools.rs: ゲートアダプタを残置し crate::runner を pub(crate) 経由で消費 (-264)
- reporter.rs/main.rs: 結果型参照を runner 直接参照へ切替え (tools 参照 0 件)

## 設計判断
- 再エクスポートでなく直接 import: reporter→tools 依存を完全切断するため
- フォーマッタは tools.rs 残置: 純粋な analysis モジュールへの ToolResult 結合を回避
- pub 可視性は保持: binary crate (src/lib.rs なし) で pub(crate) と到達可能性が同一、コードベース慣習 (pub 81 : pub(crate) 6) に準拠

## テスト
237 passed / clippy --all-targets clean / fmt clean。純移動で挙動不変。

Closes #66

https://claude.ai/code/session_01RU3XaqdYucCZiFw3294EuG