### PR TITLE
[Bug] panic→skipped 処理が join_into と lint thread の2箇所に分散しドリフトしうる

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,17 +113,10 @@ type GateTask = (
     thread::JoinHandle<Vec<runner::ToolResult>>,
 );
 
-/// Join one gate thread into `results`. Owns the panic→`skipped` mapping in one
-/// place: a panicked gate degrades to a `skipped` result per fallback name
-/// rather than aborting the hook (OUTCOME fail-open constraint).
+/// Join one gate thread into `results`, delegating the panic→`skipped` mapping
+/// to [`runner::join_or_skip`] — the single home of the fail-open policy.
 fn join_into(results: &mut Vec<runner::ToolResult>, (fallback, handle): GateTask) {
-    match handle.join() {
-        Ok(gate_results) => results.extend(gate_results),
-        Err(e) => {
-            eprintln!("gates: {} thread panicked: {e:?}", fallback.join("+"));
-            results.extend(fallback.into_iter().map(runner::ToolResult::skipped));
-        }
-    }
+    results.extend(runner::join_or_skip(handle.join(), &fallback));
 }
 
 fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Option<String> {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -201,6 +201,25 @@ pub(crate) fn run_command_with_label(
     }
 }
 
+/// Canonical statement of the panic→`skipped` fail-open policy (ADR-0001).
+///
+/// Maps a joined gate thread into results: on success the thread's results pass
+/// through unchanged; on panic the gate degrades to one `skipped` per fallback
+/// name rather than aborting the hook. Every gate join site delegates here so
+/// the policy lives in exactly one place and cannot drift between sites.
+pub fn join_or_skip(
+    joined: thread::Result<Vec<ToolResult>>,
+    fallback: &[&'static str],
+) -> Vec<ToolResult> {
+    match joined {
+        Ok(results) => results,
+        Err(e) => {
+            eprintln!("gates: {} thread panicked: {e:?}", fallback.join("+"));
+            fallback.iter().copied().map(ToolResult::skipped).collect()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,5 +284,26 @@ mod tests {
         let cmd = Command::new("nonexistent-binary-99999");
         let result = run_command("missing", cmd, Duration::from_secs(5));
         assert!(result.is_skipped());
+    }
+
+    // A non-panicking thread's results pass through join_or_skip unchanged.
+    #[test]
+    fn join_or_skip_passes_results_through_on_success() {
+        let handle = thread::spawn(|| vec![ToolResult::passed("lint")]);
+        let results = join_or_skip(handle.join(), &["lint"]);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "lint");
+        assert!(matches!(results[0].outcome, GateOutcome::Passed));
+    }
+
+    // The lint-thread fail-open path: a panicked gate degrades to skipped("lint")
+    // (ADR-0001). Pins the single-name policy the run_script_gates lint site uses.
+    #[test]
+    fn join_or_skip_maps_lint_panic_to_skipped() {
+        let handle = thread::spawn(|| -> Vec<ToolResult> { panic!("lint blew up") });
+        let results = join_or_skip(handle.join(), &["lint"]);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "lint");
+        assert!(results[0].is_skipped());
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -5,7 +5,7 @@ use crate::coupling;
 use crate::depgraph;
 use crate::project::ProjectInfo;
 use crate::resolve;
-use crate::runner::{GATE_TIMEOUT, ToolResult, run_command, run_command_with_label};
+use crate::runner::{GATE_TIMEOUT, ToolResult, join_or_skip, run_command, run_command_with_label};
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::env;
@@ -254,7 +254,7 @@ pub fn run_script_gates(gates: &[ScriptGate], project_dir: &Path) -> Vec<ToolRes
         let cmd_str = g.command.clone();
         let hint = g.hint;
         let dir = project_dir.to_path_buf();
-        thread::spawn(move || run_shell_command("lint", &cmd_str, hint, &dir))
+        thread::spawn(move || vec![run_shell_command("lint", &cmd_str, hint, &dir)])
     });
 
     if let Some(tc) = type_check {
@@ -274,13 +274,7 @@ pub fn run_script_gates(gates: &[ScriptGate], project_dir: &Path) -> Vec<ToolRes
     }
 
     if let Some(handle) = lint_handle {
-        match handle.join() {
-            Ok(r) => results.push(r),
-            Err(e) => {
-                eprintln!("gates: lint thread panicked: {e:?}");
-                results.push(ToolResult::skipped("lint"));
-            }
-        }
+        results.extend(join_or_skip(handle.join(), &["lint"]));
     }
 
     results


### PR DESCRIPTION
## 概要と背景

panic→skipped の fail-open 方針(ADR-0001: パニックしたゲートはフックを中断せず1件の `Skipped` に降格)が `main::join_into` と `run_script_gates` の lint thread の2箇所で独立実装されており、片方の変更が他方へ届かずドリフトしうる状態だった。方針を `runner::join_or_skip` の1箇所へ集約してこの重複を解消する。

## 変更点

- `runner::join_or_skip` を新設 — joined スレッド結果を受け、成功は通過、パニックは fallback 名ごとに1件の `skipped` へ降格する方針の唯一の定義箇所。doc comment が ADR-0001 の正規記述を兼ねる
- `main::join_into` を `join_or_skip` への委譲に置換(自前の match を除去)
- `run_script_gates` の lint thread を `Vec<ToolResult>` 返却へ変更し、ローカルの `eprintln`+`skipped("lint")` を `join_or_skip` 経由へ統合

## スコープ

- 挙動は不変: stderr メッセージは `"lint".join("+") == "lint"` ゆえバイト同一、結果順序も lint を最後に join する点が変わらず不変

## 設計判断

- 配置先は `runner.rs`。`main` が `tools` に依存する向きのため tools から `join_into` は呼べず、`ToolResult`/`skipped` を既に所有する最下層の共有モジュール `runner` がヘルパーの唯一の置き場所
- lint panic→skipped の検証は `join_or_skip` の policy テスト＋目視配線確認に留める。`run_shell_command` を実際にパニックさせる注入経路がないため end-to-end ではなく policy テストで担保(priority:low の保守性 fix として許容)

## テスト方法

1. `cargo test --bin gates` — 241 tests green(新規 `join_or_skip_passes_results_through_on_success` / `join_or_skip_maps_lint_panic_to_skipped` を含む)
2. `cargo clippy --bin gates` と `cargo fmt --check` — 警告・差分なし

## 関連

- Closes #74