### PR TITLE
docs(adr): ADR-0001 のドリフトを #76/#77 後の実装へ追従

### DIFF
--- a/docs/audit/2026-06-24-042124-adr-drift.md
+++ b/docs/audit/2026-06-24-042124-adr-drift.md
@@ -1,0 +1,59 @@
+# ADR Drift Scan: 2026-06-24-042124
+
+## Summary
+
+| Metric            | Value |
+| ----------------- | ----- |
+| ADRs scanned      | 4     |
+| Drift findings    | 3     |
+| H priority        | 0     |
+| M priority        | 0     |
+| L priority        | 3     |
+| Unverifiable ADRs | 0     |
+
+All four ADRs are `accepted`; none superseded. Every binding contract symbol and Confirmation test is intact in code. The three findings are all L-priority and confined to ADR-0001's prose: line-number references in its Context and Confirmation drifted behind refactors merged after the ADR was authored (PR #66/#72 runner extraction, #76 DFS stackification, #77 join_or_skip consolidation). ADR-0002/0003/0004 show no actionable drift.
+
+## Per-ADR Findings
+
+### ADR 0001: Adopt fail-open invariant for all gates
+
+Status: Accepted
+
+The binding contract holds: `GateOutcome::Skipped` (runner.rs:34), `join_into` (main.rs:118), and all Confirmation tests (`invalid_json_enables_all_gates`, `query_skips_corrupt_lines`, `join_into_maps_panic_to_skipped_per_fallback_name`) exist. Drift is in the prose line-refs, which post-date refactors #66/#72/#76/#77.
+
+| #   | File:Line              | Description                                                                                                                                                                                                                                   | Direction  | Priority |
+| --- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------- |
+| 1   | docs/decisions/0001:11 | Context cites ad-hoc fail-open sites `tools.rs:48,619; main.rs:300; config.rs:68` that no longer point at fail-open code (tools.rs:48 is now an oxlint doc-comment, config.rs:68 is `fn load`). Only runner.rs:13 and main.rs:96 still match. | adr-update | L        |
+| 2   | docs/decisions/0001:37 | Confirmation names only `main::join_into` as the join path. PR #77 added `runner::join_or_skip` (runner.rs:204, "Canonical statement of the panic→skipped fail-open policy (ADR-0001)") as the single error sink; the ADR should name it.     | adr-update | L        |
+| 3   | docs/decisions/0001:33 | Consequences cites "stack overflow … can still bypass it"; PR #76 stackified circular.rs DFS (the Reassessment Trigger fired and was bug-fixed). The general claim holds for other gates, but the example is now mitigated.                   | accept     | L        |
+
+### ADR 0002: Embed oxc-based analysis instead of shelling out to external tools
+
+Status: Accepted
+
+No drift. `oxc_*` imports present (depgraph.rs:1-4); shared single-parse graph documented at depgraph.rs:11-13; `resolve_import` honors `.ts/.tsx/index` only, no tsconfig aliases (depgraph.rs:131-157, cite accurate). PR #76 converted circular.rs from recursive to iterative DFS, but it remains three-color back-edge detection (circular.rs Color enum + `dfs`/`record_cycle`); the ADR makes no recursion claim, so the `circular.rs:27-99` cite and the back-edge-vs-SCC trade-off statement stay valid.
+
+### ADR 0003: Commit to a stable audit.jsonl on-disk schema
+
+Status: Accepted
+
+No actionable drift. `AuditEntry` carries exactly the four frozen fields `ts, project, decision, failed` with no renames (audit.rs:15-21; ADR cites 14-21, a 1-line cosmetic shift). The single-`write_all` PIPE_BUF atomicity note matches audit.rs append path. No field has yet been added, so the `#[serde(default)]` rule is untested but uncontradicted.
+
+### ADR 0004: Define the default-enable policy for gates
+
+Status: Accepted
+
+No drift. `is_enabled` (config.rs:61-66, cite exact) implements the two-tier rule verbatim: `None => true`, `Some(map) => *map.get(name).unwrap_or(&false)`. Confirmation tests `missing_file_enables_all_gates` and `partial_gates_section` exist (config.rs). `CONFIG_HINT` exists (main.rs:39) as the announce surface named in Consequences.
+
+## External ADR Dependencies
+
+The adrift `_lib/external-adr-refs.py` helper is absent from the installed skill; this cross-check was performed manually via `ugrep "ADR-[0-9]{4}"`. ADR-0066 and ADR-0060 are referenced in code and README but have no `NNNN-*.md` under `docs/decisions/` (they live in the shared dotclaude config repo).
+
+| #   | File:Line                                 | External ADR ref     | Recommended action                                                                                          |
+| --- | ----------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------- |
+| 1   | README.md:181, hook_exit.rs:1, main.rs:28 | ADR-0066 (not local) | Keep as external dependency on shared dotclaude config; promote locally only if hook exit-code policy forks |
+| 2   | hook_exit.rs:23, main.rs:36               | ADR-0060 (not local) | Keep as external dependency (gates show I/O code); promote locally only if it diverges from upstream        |
+
+## Follow-up Issue Candidates
+
+None at H priority. The three L findings are ADR-body edits suited to a single `/adr` touch-up of 0001, not separate issues.

--- a/docs/decisions/0001-adopt-fail-open-invariant-for-all-gates.md
+++ b/docs/decisions/0001-adopt-fail-open-invariant-for-all-gates.md
@@ -8,7 +8,7 @@ decision-makers: [thkt]
 
 ## Context and Problem Statement
 
-gates runs as a PostToolUse hook on every AI edit. A gate that throws, times out, finds no binary, or panics must never block the agent's edit cycle. Today this behavior is implemented ad hoc at each gate site (tools.rs:48,619; main.rs:96,300,489; config.rs:68; audit.rs:1-3; runner.rs:13) and stated as a fact in OUTCOME.md:49, but no rule obliges a future-added gate to follow it. A new contributor can write a gate that returns `Result` and propagates an error, silently breaking the never-block contract. How do we make fail-open a binding rule rather than a coincidence of the current code?
+gates runs as a PostToolUse hook on every AI edit. A gate that throws, times out, finds no binary, or panics must never block the agent's edit cycle. This behavior is funneled through `runner::join_or_skip` (runner.rs:204) — the single sink reached from `join_into` (main.rs:118), degrading a failed gate to `GateOutcome::Skipped` (runner.rs:16) — and stated as a fact in OUTCOME.md, but no rule obliges a future-added gate to route its error paths there. A new contributor can write a gate that returns `Result` and propagates an error, silently breaking the never-block contract. How do we make fail-open a binding rule rather than a coincidence of the current code?
 
 ## Decision Drivers
 
@@ -30,11 +30,11 @@ Chosen option: ADR + funnel-to-Skipped convention, because the invariant is not 
 
 - Good, because every new gate has one rule to follow: any error/timeout/panic/missing-binary path resolves to `GateOutcome::Skipped`, never a propagated error or non-zero hook exit
 - Good, because the agent's edit cycle is protected by an explicit contract, not scattered precedent
-- Bad, because enforcement stays manual (code review), so a gate that crashes the process (e.g. stack overflow, see Reassessment Triggers) can still bypass it
+- Bad, because enforcement stays manual (code review), so a gate that crashes the process (e.g. stack overflow, see Reassessment Triggers) can still bypass it. The one known such path, recursive DFS in circular.rs, was since stackified to bounded-heap iteration; other gates remain unguarded
 
 ### Confirmation
 
-Code review of any new gate: confirm every error path returns `GateOutcome::Skipped` and the gate's thread is joined through `main::join_into` with fallback names. Existing tests `invalid_json_enables_all_gates`, `query_skips_corrupt_lines`, and the panic→skipped join tests guard the established sites.
+Code review of any new gate: confirm every error path returns `GateOutcome::Skipped` and the gate's thread is joined through `main::join_into` (main.rs:118), which delegates to `runner::join_or_skip` (runner.rs:204) — the single home of the policy — with fallback names. Existing tests `invalid_json_enables_all_gates`, `query_skips_corrupt_lines`, and the panic→skipped join test `join_into_maps_panic_to_skipped_per_fallback_name` guard the established sites.
 
 ## More Information
 


### PR DESCRIPTION
## 背景

`/adrift` スキャンで ADR-0001「fail-open invariant」の散文行参照が、ADR 作成後にマージされた #76(circular.rs DFS 反復化)/#77(join_or_skip 集約)とズレていることを検出した。契約シンボル(`GateOutcome::Skipped`、`join_into`)と Confirmation テストは全て健在で、ドリフトは散文に限定される。

## 変更

| 箇所 | 内容 |
| --- | --- |
| Context | 旧散在サイト行参照(tools.rs:48,619 等)を削除し、`runner::join_or_skip`(runner.rs:204)単一シンク・`join_into`(main.rs:118)経由・`GateOutcome::Skipped`(runner.rs:16)へ差し替え |
| Consequences | stack overflow バイパス記述に「既知の唯一経路 circular.rs 再帰 DFS は #76 で反復化済み、他ゲートは未防御」を追記 |
| Confirmation | `join_into`→`join_or_skip` 委譲を明記、テスト名を実名 `join_into_maps_panic_to_skipped_per_fallback_name` へ修正 |
| docs/audit | 4 ADR のドリフトスキャンレポートを追加(H:0 M:0 L:3、検証不能:0) |

ADR-0002/0003/0004 は実コードと整合のため変更なし。

https://claude.ai/code/session_01WnMPVeUMrfzzwK7wZ7sw8q