### PR TITLE
chore: v0.11.0 をリリース

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "gates"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "litmus",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gates"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2024"
 description = "Claude Code completion hook for parallel gate execution"
 license = "MIT"


### PR DESCRIPTION
## 概要

`v0.10.1`（2026-03-22）以降に main へ蓄積された約60コミットをリリースするためのバージョン bump（`0.10.1` → `0.11.0`）。新ゲート複数追加・新サブコマンド・exit-code 整合など機能追加が中心のため minor bump。

## 主な変更

### 新ゲート
- `feat(gates)`: oxlint `--type-aware` 静的ゲート (#60)
- `feat(gates)`: dependency-cruiser によるアーキテクチャ境界違反検出 (#48)
- `feat(gates)`: 結合度メトリクスゲート (Ca/Ce/instability, God module 検出) (#49)
- `feat(gates)`: oxc AST ハッシュによる構造的コードクローン検出 (#50)
- `feat(gates)`: jscpd 重複コード検出ゲート (#51)

### 機能追加
- `feat(audit)`: 永続監査ログと `show` サブコマンド (#52)
- `feat(show)`: `--json` 出力 (sysexits / BrokenPipe ハンドリング) (#53)
- `feat(post-bash)`: filesystem-delta digest による bash 経由編集の検出 (#54)
- `feat(exit-code)`: ADR-0066 Group 3 (Hook tool) へ exit code を整合 (#56)

### 修正
- `fix(circular)`: 再帰 DFS をスタック反復化し深い依存グラフの SIGABRT を解消 (#76)
- `fix(runner)`: panic→skipped 方針を `join_or_skip` へ集約 (#77)

### その他
- リファクタ多数 (runner/reporter/config 構造整理)、ADR 0001-0004 追加、Renovate 移行、CI baseline 整合、release バイナリの sentinels ミラー公開 (#58)

詳細な変更履歴はタグ push 時の GitHub Release（自動生成リリースノート）に記載されます。

## リリース手順（マージ後）

1. main で `v0.11.0` タグを作成・push
2. `release.yml` が起動し、4ターゲットバイナリビルド → Release作成 → homebrew-tap / sentinels 同期

https://claude.ai/code/session_01VtMmzLk9tjnmPG7GQDq976
