### PR TITLE
ci(release): create-github-app-token を app-id から client-id へ移行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SENTINELS_APP_ID }}
+          client-id: ${{ secrets.SENTINELS_APP_CLIENT_ID }}
           private-key: ${{ secrets.SENTINELS_APP_PRIVATE_KEY }}
           owner: thkt
           repositories: sentinels
@@ -244,7 +244,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.SENTINELS_APP_ID }}
+          client-id: ${{ secrets.SENTINELS_APP_CLIENT_ID }}
           private-key: ${{ secrets.SENTINELS_APP_PRIVATE_KEY }}
           owner: thkt
           repositories: sentinels


### PR DESCRIPTION
## 概要

`actions/create-github-app-token` v3 系で非推奨となった `app-id` 入力を `client-id` へ移行し、release 実行時の deprecation warning を解消する。Closes #81

## 変更

`.github/workflows/release.yml` の2ジョブ（`update-sentinels` / `publish-binaries-to-sentinels`）の `app-id: ${{ secrets.SENTINELS_APP_ID }}` を `client-id: ${{ secrets.SENTINELS_APP_CLIENT_ID }}` に置換。

## ⚠️ マージ前提条件

secret `SENTINELS_APP_CLIENT_ID`（GitHub App の Client ID, `Iv23…` 形式）の登録が必須。未登録のままマージすると App トークン生成に失敗し release が壊れるため、**secret 登録とマージを同タイミングで行うこと**。既存の `SENTINELS_APP_ID`（数値 App ID）は client-id とは別物。

## 確認

actionlint クリーン。

https://claude.ai/code/session_01VtMmzLk9tjnmPG7GQDq976