### PR TITLE
fix(jscpd): .git ディレクトリを既定 ignore に追加

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -524,8 +524,11 @@ pub const DEFAULT_JSCPD_THRESHOLD: f64 = 10.0;
 /// `node_modules` is normally excluded by jscpd's gitignore handling, but is
 /// listed here so a repo that does not gitignore it still skips the scan (which
 /// would otherwise blow the gate's timeout). jscpd's own docs use this glob.
+/// `.git` is not covered by gitignore (it is the git dir itself); its sample
+/// hooks are near-identical and would surface as clone groups, so exclude it.
 pub const DEFAULT_JSCPD_IGNORE: &[&str] = &[
     "**/node_modules/**",
+    "**/.git/**",
     "**/*.test.*",
     "**/*.spec.*",
     "**/generated/**",
@@ -1500,6 +1503,40 @@ test('works', () => {
             result.is_skipped(),
             "stale report must not be read as the current run: {}",
             result.output()
+        );
+    }
+
+    // The default ignore list keeps jscpd out of the `.git` directory, whose
+    // sample hooks are near-identical and would otherwise surface as clone
+    // groups. Verify the glob reaches jscpd's `--ignore` argument end to end.
+    #[test]
+    fn jscpd_default_ignore_excludes_git_dir() {
+        let _guard = JSCPD_RUN_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let tmp = TempDir::new("jscpd-args");
+        fs::write(tmp.join("package.json"), "{}").unwrap();
+        link_fake_bin(&tmp, "jscpd", "jscpd-record-args");
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: true,
+            has_tsconfig: false,
+        };
+
+        let ignore: Vec<String> = DEFAULT_JSCPD_IGNORE
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect();
+        let _ = run_jscpd(&project, 5, 50, 10.0, false, &ignore);
+
+        let args = fs::read_to_string(tmp.join("jscpd-args.txt")).unwrap();
+        let ignore_line = args
+            .lines()
+            .find(|l| l.contains("**/.git/**") || l.contains(','))
+            .unwrap_or("");
+        assert!(
+            ignore_line.contains("**/.git/**"),
+            "jscpd --ignore must exclude the .git dir, got args:\n{args}"
         );
     }
 }

--- a/tests/fixtures/jscpd-record-args
+++ b/tests/fixtures/jscpd-record-args
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Records the full argument list (one per line) to jscpd-args.txt in the cwd,
+# then writes no report so run_jscpd treats the run as a fail-open skip.
+for a in "$@"; do
+  printf '%s\n' "$a" >>jscpd-args.txt
+done
+exit 0


### PR DESCRIPTION
## 背景
jscpd ゲートが `.git/hooks/*.sample` を重複として誤検出していた。これらは git init が生成するほぼ同一の雛形シェルスクリプトで、`min-lines 3` で **14 クローン群**を生成し gate 出力を汚す。`.git` は gitignore 対象外(git dir 自身)のため jscpd の gitignore 連携では除外されず、明示的な ignore 指定が必要。

## 変更
- `DEFAULT_JSCPD_IGNORE` に `**/.git/**` を追加
- 引数記録 fixture `jscpd-record-args` を追加し、既定 ignore が `run_jscpd` 経由で jscpd の `--ignore` へ `**/.git/**` を渡すことをエンドツーエンド検証するテスト `jscpd_default_ignore_excludes_git_dir` を追加

## 検証
- 全 242 テスト緑、clippy クリーン
- 実 jscpd での before/after: `.git` 除外なし → clone 群 2・`.git` 出現あり、除外あり → clone 群 1(src 重複のみ)・`.git` 出現 0
- gates バイナリ実行で本物の src 重複は引き続き block、`.git` ノイズのみ消失

https://claude.ai/code/session_019JizH5AXbSW4ogyVoH9fge