### PR TITLE
chore: バージョンを 0.11.1 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "gates"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "litmus",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gates"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 description = "Claude Code completion hook for parallel gate execution"
 license = "MIT"


### PR DESCRIPTION
## 概要

`v0.11.0` 以降の未リリース分を 0.11.1 として切り出すための version bump。

## 含まれる未リリース変更

- #82 ci(release): create-github-app-token を app-id から client-id へ移行
- #83 fix(jscpd): .git ディレクトリを既定 ignore に追加

ユーザ向けの挙動変更は #83 の fix 1 件のため patch を採用。

## 変更

- `Cargo.toml` / `Cargo.lock`: `0.11.0` → `0.11.1`

## リリース手順（マージ後）

マージ後の bump コミットに `v0.11.1` タグを打って push すると `release.yml` が起動する。

https://claude.ai/code/session_011MDAkNuwXk4Z9bp75vu4ed