### PR TITLE
litmus を 805cad61 へ更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "litmus"
 version = "0.3.0"
-source = "git+https://github.com/thkt/litmus.git#1cc3591b1031444ee6312dbf181265d93f2be873"
+source = "git+https://github.com/thkt/litmus.git#805cad61eaa614069b8121c9779bdb7e667ad1b8"
 dependencies = [
  "glob",
  "oxc_allocator",


### PR DESCRIPTION
## 概要と目的

litmus git 依存を最新へ更新する。`Cargo.toml` は branch/tag 固定なしの git 依存のため、`cargo update -p litmus` で lockfile を最新 commit に進める。

## 変更点

- `Cargo.lock`: litmus を `1cc3591b` から `805cad61` (リモート HEAD) へ更新。

## テスト方法

1. `cargo build` → 成功。
2. `cargo test --quiet` → 251 passed、回帰なし。

https://claude.ai/code/session_015GuLTpRd1aGaHyPDEDyg4A