### PR TITLE
バージョンを 0.12.0 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "gates"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "litmus",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gates"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 description = "Claude Code completion hook for parallel gate execution"
 license = "MIT"


### PR DESCRIPTION
## 概要と目的

0.11.1 以降の変更を minor リリース 0.12.0 として公開する。feat(tools) #90 の機能追加を含むため semver minor bump。

## 変更点

- `Cargo.toml` / `Cargo.lock`: version を `0.11.1` から `0.12.0` へ。

## 含まれる変更 (0.11.1 以降)

- feat(tools): 未ブートストラップ env の type gate 失敗を advisory へ降格 (#90)
- chore(deps): litmus を 805cad61 へ更新 (#91)
- chore(deps): CI action 群を更新 (#85-#88)

## テスト方法

1. `cargo build` → 成功。
2. マージ後に `v0.12.0` タグを push → release.yml がバイナリビルドと GitHub Release を生成。

https://claude.ai/code/session_015GuLTpRd1aGaHyPDEDyg4A