### PR TITLE
feat: walk_ancestorsに$HOMEフェンスを追加しformatterと整合

### DIFF
--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -1,15 +1,27 @@
-use std::path::Path;
+use std::env;
+use std::path::{Path, PathBuf};
 
 const MAX_TRAVERSAL_DEPTH: usize = 20;
 
-/// Stops at `.git` boundary (after visiting that directory) or depth limit.
+/// Stops at the `.git` boundary (after visiting that directory), at `$HOME`
+/// (which is inspected but whose ancestors are not), or at the depth limit.
+/// The `$HOME` fence mirrors formatter's `bounded_ancestors` so the two
+/// resolvers' ancestor walks stay aligned (independent copies, no drift). The
+/// third sibling, guardrails, deliberately keeps a different model
+/// (`canonicalize` + `project_root` boundary, no fences) to preserve its
+/// `OutsideProjectRoot` forensic signal — so it is not unified with this walk.
 pub fn walk_ancestors<T>(start: &Path, mut visitor: impl FnMut(&Path) -> Option<T>) -> Option<T> {
+    let home = env::var_os("HOME").map(PathBuf::from);
     let mut current = start;
     for _ in 0..MAX_TRAVERSAL_DEPTH {
         if let Some(result) = visitor(current) {
             return Some(result);
         }
         if current.join(".git").exists() {
+            break;
+        }
+        // Inspect `$HOME` itself, then fence out everything above it.
+        if home.as_deref() == Some(current) {
             break;
         }
         match current.parent() {


### PR DESCRIPTION
## 概要

4つの兄弟CLI(formatter/guardrails/gates)のbinリゾルバを独立コピーのまま「ずれなく」整合する作業の一環。gatesの`walk_ancestors`に`$HOME`フェンスを追加し、formatterの`bounded_ancestors`とwalk骨格を揃える。

## 変更

- `walk_ancestors`: `$HOME`を検査した後その上位ディレクトリを辿らないフェンスを追加(`$HOME`自体は検査するが、それより上には抜けない)。formatterの`bounded_ancestors`と同一意味論。`resolve`と`project`の両呼び出し元が恩恵を受ける(プロジェクトルート探索が`$HOME`を超えない)。
- docコメント: 3つ目の兄弟guardrailsが`canonicalize` + `project_root`境界という別モデルを意図的に維持する旨を明文化(`OutsideProjectRoot`フォレンジック信号をフェンスが潰す退行を避けるため)。

## テスト

`$HOME`フェンスは`$TMPDIR`(=`$HOME`外)で走るテストでは発火せず、深さcap + `.git`フェンスの内側で働く防御境界。formatter(参照実装)が専用テストを持たずenv書き換えが並列テストとレースするため、formatterに揃えて内部HOME読みのみとし専用テストは追加しない。`cargo test`(251)・`cargo clippy`グリーン。

https://claude.ai/code/session_01MFn4KsMceVZ5JDCFsveCK8