### PR TITLE
litmus 統合契約の問題: advisory を block 化 / subprocess 隔離喪失 / fix 前 commit に pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "litmus"
 version = "0.3.0"
-source = "git+https://github.com/thkt/litmus.git#805cad61eaa614069b8121c9779bdb7e667ad1b8"
+source = "git+https://github.com/thkt/litmus.git?rev=4ee5b6a6875ba6e7dfa210fc6b98cbc528603272#4ee5b6a6875ba6e7dfa210fc6b98cbc528603272"
 dependencies = [
  "glob",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,11 @@ path = "src/main.rs"
 serde = { version = "1", features = ["derive"] }
 serde_json = ">=1"
 regex = ">=1"
-litmus = { git = "https://github.com/thkt/litmus.git" }
+# litmus is a first-party git dependency with no semver releases. A bare git dep
+# floats to the default-branch HEAD on `cargo update`, which is a stability hazard
+# for a per-edit hook, so pin it by rev. The registry crates below (oxc/serde/regex)
+# stay on `>=` ranges; pinning those floats is tracked separately, out of #94 scope.
+litmus = { git = "https://github.com/thkt/litmus.git", rev = "4ee5b6a6875ba6e7dfa210fc6b98cbc528603272" }
 oxc_allocator = ">=0.121"
 oxc_ast = { version = ">=0.121", features = ["serialize"] }
 oxc_parser = ">=0.121"

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,10 +164,7 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
 
     if config.is_enabled("litmus") {
         let p = project.clone();
-        tasks.push((
-            vec!["litmus"],
-            thread::spawn(move || vec![tools::run_litmus(&p)]),
-        ));
+        tasks.push((vec!["litmus"], thread::spawn(move || tools::run_litmus(&p))));
     }
 
     if circular_enabled || coupling_enabled {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -8,12 +8,14 @@ use crate::resolve;
 use crate::runner::{
     GATE_TIMEOUT, GateOutcome, ToolResult, join_or_skip, run_command, run_command_with_label,
 };
+use litmus::rules::{Issue, Severity};
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::io;
 use std::iter;
+use std::panic::resume_unwind;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::process::Command;
@@ -330,33 +332,109 @@ pub fn gate_by_name(name: &str) -> &'static GateDefinition {
         .unwrap_or_else(|| panic!("gate '{name}' not found"))
 }
 
-pub fn run_litmus(project: &ProjectInfo) -> ToolResult {
+// litmus calibrates its parser's stack headroom against this size: its CLI runs
+// `analyze_files` on a 256MiB worker (litmus `ANALYZER_STACK_SIZE`, src/main.rs).
+// The library path we use here would otherwise run on a default ~2MiB gate thread,
+// where right-associative forms with no brackets to bound recursion (`a=b=c`,
+// ternary alternate, `**`, prefix-unary) overflow far sooner than litmus expects.
+// Mirroring the size lifts the overflow floor to litmus's ~250k-level parity.
+//
+// This is probability reduction, not containment: a deeper overflow still aborts
+// via SIGABRT, which is signal death that `join_or_skip` cannot catch and which
+// takes the whole gates process down with it. True isolation needs a subprocess
+// or an upstream litmus `analyze_files_isolated` entry (out of #94 scope).
+//
+// The value duplicates litmus's unexported `ANALYZER_STACK_SIZE`, which litmus
+// couples to its `BRACKET_DEPTH_LIMIT`; re-verify this number whenever the pinned
+// litmus rev (Cargo.toml) is bumped.
+const ANALYZER_STACK_SIZE: usize = 256 * 1024 * 1024;
+
+/// Run `litmus::analyze_files` on a thread with `ANALYZER_STACK_SIZE`, matching
+/// litmus's own worker so the library path has the same overflow floor as its CLI.
+/// A child panic is re-raised on the caller so the gate thread's `join_or_skip`
+/// still degrades it to skipped (fail-open). If the thread cannot be spawned we
+/// fall back to an inline call, mirroring litmus's main-thread fallback.
+fn analyze_files_on_deep_stack(files: &[PathBuf]) -> litmus::AnalysisResult {
+    thread::scope(|scope| {
+        match thread::Builder::new()
+            .stack_size(ANALYZER_STACK_SIZE)
+            .spawn_scoped(scope, || litmus::analyze_files(files))
+        {
+            Ok(handle) => match handle.join() {
+                Ok(result) => result,
+                Err(payload) => resume_unwind(payload),
+            },
+            Err(error) => {
+                eprintln!("gates: litmus deep-stack thread spawn failed, running inline: {error}");
+                litmus::analyze_files(files)
+            }
+        }
+    })
+}
+
+pub fn run_litmus(project: &ProjectInfo) -> Vec<ToolResult> {
     if !project.has_package_json {
-        return ToolResult::skipped("litmus");
+        return vec![ToolResult::skipped("litmus")];
     }
 
     let files = litmus::find_test_files(&project.root);
     if files.is_empty() {
-        return ToolResult::skipped("litmus");
+        return vec![ToolResult::skipped("litmus")];
     }
 
-    let result = litmus::analyze_files(&files);
+    let result = analyze_files_on_deep_stack(&files);
 
     for error in &result.errors {
         eprintln!("gates: {error}");
     }
 
     if result.issues.is_empty() {
-        return ToolResult::passed("litmus");
+        return vec![ToolResult::passed("litmus")];
     }
 
-    let output: Vec<String> = result.issues.iter().map(ToString::to_string).collect();
+    // litmus tags dummy-data / missing-act / snapshot-external as advisory
+    // (`Severity::Warning`, exit 1 in its CLI) and everything else as blocking
+    // (exit 2). Route each tier to gates' matching outcome so warnings reach the
+    // human without blocking the AI, and surface both when they co-occur rather
+    // than letting a blocking result swallow the warnings (gates can emit more
+    // than one result per gate, e.g. run_graph_gates).
+    // Match exhaustively rather than `== Severity::Warning`: `Severity` is not
+    // `#[non_exhaustive]`, so a future litmus variant breaks compilation here and
+    // forces a deliberate routing choice, instead of silently defaulting to the
+    // blocking bucket and blocking the AI against gates' fail-open posture.
+    let (warnings, blocking): (Vec<_>, Vec<_>) =
+        result
+            .issues
+            .iter()
+            .partition(|issue| match issue.severity() {
+                Severity::Warning => true,
+                Severity::Blocking => false,
+            });
 
-    ToolResult::failed(
-        "litmus",
-        "Fix test quality issues (weak assertions, mock overuse, tautological tests).",
-        &output.join("\n"),
-    )
+    let render = |issues: &[&Issue]| {
+        issues
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let mut results = Vec::new();
+    if !blocking.is_empty() {
+        results.push(ToolResult::failed(
+            "litmus",
+            "Fix test quality issues (weak assertions, mock overuse, tautological tests).",
+            &render(&blocking),
+        ));
+    }
+    if !warnings.is_empty() {
+        results.push(ToolResult::warned(
+            "litmus",
+            "Advisory test-quality warnings (litmus warning tier); not blocking.",
+            &render(&warnings),
+        ));
+    }
+    results
 }
 
 /// Build the dependency graph once and run the circular and coupling gates that
@@ -1414,7 +1492,7 @@ mod tests {
     fn litmus_skips_without_package_json() {
         let project = test_project(false, false);
         let result = run_litmus(&project);
-        assert!(result.is_skipped());
+        assert!(result.iter().any(ToolResult::is_skipped));
     }
 
     #[test]
@@ -1427,7 +1505,7 @@ mod tests {
             has_tsconfig: false,
         };
         let result = run_litmus(&project);
-        assert!(result.is_skipped());
+        assert!(result.iter().any(ToolResult::is_skipped));
     }
 
     #[test]
@@ -1455,9 +1533,8 @@ describe('math', () => {
         };
         let result = run_litmus(&project);
         assert!(
-            !result.is_failure(),
-            "good test should pass: {:?}",
-            result.outcome
+            !result.iter().any(ToolResult::is_failure),
+            "good test should pass: {result:?}"
         );
     }
 
@@ -1481,8 +1558,97 @@ test('works', () => {
             has_tsconfig: false,
         };
         let result = run_litmus(&project);
-        assert!(result.is_failure(), "tautological test should fail");
-        assert!(result.output().contains("tautological"));
+        assert!(
+            result.iter().any(ToolResult::is_failure),
+            "tautological test should fail"
+        );
+        assert!(
+            !result.iter().any(ToolResult::is_warning),
+            "no warning tier"
+        );
+        let blocking_output: String = result
+            .iter()
+            .filter(|r| r.is_failure())
+            .map(ToolResult::output)
+            .collect();
+        assert!(blocking_output.contains("tautological"));
+    }
+
+    #[test]
+    fn litmus_warns_without_blocking_on_warning_tier() {
+        // dummy-data is a warning-tier rule (advisory, exit 1 in litmus' CLI):
+        // the test exercises a real act yet feeds placeholder "foo"/"FOO" data.
+        let tmp = TempDir::new("litmus-warn");
+        fs::write(tmp.join("package.json"), "{}").unwrap();
+        fs::write(
+            tmp.join("warn.test.ts"),
+            r#"
+import { test, expect } from 'vitest';
+test("uppercases the provided first name", () => {
+    const result = normalize("foo");
+    expect(result).toBe("FOO");
+});
+"#,
+        )
+        .unwrap();
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: true,
+            has_tsconfig: false,
+        };
+        let result = run_litmus(&project);
+        assert!(
+            result.iter().any(ToolResult::is_warning),
+            "warning-tier issue should warn: {result:?}"
+        );
+        assert!(
+            !result.iter().any(ToolResult::is_failure),
+            "warning-tier issue must not block: {result:?}"
+        );
+    }
+
+    #[test]
+    fn litmus_reports_both_tiers_when_mixed() {
+        // A blocking rule (tautological) and a warning rule (dummy-data) in the
+        // same run must both surface; the blocking result must not swallow the
+        // warning.
+        let tmp = TempDir::new("litmus-mixed");
+        fs::write(tmp.join("package.json"), "{}").unwrap();
+        fs::write(
+            tmp.join("block.test.ts"),
+            r"
+import { test, expect } from 'vitest';
+test('works', () => {
+    expect(true).toBe(true);
+});
+",
+        )
+        .unwrap();
+        fs::write(
+            tmp.join("warn.test.ts"),
+            r#"
+import { test, expect } from 'vitest';
+test("uppercases the provided first name", () => {
+    const result = normalize("foo");
+    expect(result).toBe("FOO");
+});
+"#,
+        )
+        .unwrap();
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: true,
+            has_tsconfig: false,
+        };
+        let result = run_litmus(&project);
+        assert!(
+            result.iter().any(ToolResult::is_failure),
+            "mixed run should keep the blocking result: {result:?}"
+        );
+        assert!(
+            result.iter().any(ToolResult::is_warning),
+            "mixed run should keep the warning result: {result:?}"
+        );
     }
 
     fn clone_project(files: &[(&str, &str)]) -> TempDir {


### PR DESCRIPTION
## 概要

litmus 統合契約の3問題を修正。close #94。

| ID | 問題 | 修正 |
| --- | --- | --- |
| A1 | gates が litmus の severity tier を無視し advisory issue でも AI をハードブロック | `run_litmus` を `Vec<ToolResult>` 化、`Severity::Warning` を advisory な `Warned` へ、`Severity::Blocking` のみ `Failed` へ分離 |
| A3 | library-path 統合で subprocess 隔離を喪失。litmus parser の SIGABRT が gates プロセス全体を kill | `analyze_files` を 256MiB stack thread（litmus CLI の `ANALYZER_STACK_SIZE` と同等）上で実行 |
| A4 | floating git dep が fix 前 commit 805cad6 に pin され `cargo update` で float | fix 後 HEAD `4ee5b6a` へ rev pin |

## 設計判断

- **A1 は非可逆損失なし**: collapse せず `Vec` で `Failed`+`Warned` 両方を返す。reporter は両 tier を同時描画する（既存テストで実証）。exhaustive match で将来の litmus variant を compile error 化。
- **A3 は probability reduction であり containment ではない**: 256MiB stack は SIGABRT 発生確率を litmus CLI と同 floor（約250k 再帰段）まで下げるが、より深い overflow による残存 SIGABRT はプロセスを kill する既知 gap。真の隔離（subprocess / 上流 `analyze_files_isolated`）は library 統合という設計選択と矛盾し per-edit コストを伴うため、実 abort 観測時に上流 litmus issue として起票（#94 scope 外）。
- **fail-open の2軸整理**: 「AI を誤ってブロックしない」軸は SIGABRT 下でも成立（プロセス死 = stdout なし = block JSON なし）。失われるのは per-gate の skipped degradation 軸。child panic は `resume_unwind` で gate thread へ再伝播し `join_or_skip` が skipped 化する。
- **A4 を別コミットに分離**: dep bump は logic と risk/rollback プロファイルが異なり bisect 可能性を保つため。delta `805cad6..4ee5b6a` は Warning-tier 誤検知修正のみで block-rule 変更なし。

## 既知の制限

- embedded gate（litmus/circular/coupling）には per-gate timeout がない。これは本 PR 以前からの既存事項で #94 scope 外。
- `ANALYZER_STACK_SIZE = 256MiB` は litmus の未 export 定数の手動複製。`BRACKET_DEPTH_LIMIT` と coupling し、A4 の rev bump 時に再検証が必要（コードコメントに明記）。

## テスト

- 新規: `litmus_warns_without_blocking_on_warning_tier`（warning-tier 単独で `Warned` のみ）、`litmus_reports_both_tiers_when_mixed`（混在で `Failed`+`Warned` 両方）。
- 全 253 テスト green、clippy/fmt clean。

https://claude.ai/code/session_016sgb3rgG1482AxusuSTyuw
