### PR TITLE
gate override の環境変数が無印で衝突・命名規約から逸脱 (LINT_CMD/TEST_CMD 等)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,7 +59,7 @@ Claude Codeの[PostToolUseフック](https://docs.anthropic.com/en/docs/claude-c
 | type-check | `"test:type"` or `"typecheck"` | 独立実行                    |
 | test       | `"test:unit"` or `"test"`      | type-check 失敗時はスキップ |
 
-ロックファイルが見つからない場合、スクリプトゲートは静かにスキップされます（フェイルオープン）。環境変数オーバーライド（`$LINT_CMD`, `$TYPE_CMD`, `$UNIT_CMD`）を使うと自動検出をバイパスして直接コマンドを実行できます。
+ロックファイルが見つからない場合、スクリプトゲートは静かにスキップされます（フェイルオープン）。環境変数オーバーライド（`$GATES_LINT_CMD`, `$GATES_TYPE_CMD`, `$GATES_UNIT_CMD`）を使うと自動検出をバイパスして直接コマンドを実行できます。
 
 ## 必要なツール
 
@@ -212,14 +212,14 @@ gates は ADR-0066 Group 3 (Hook tool) の終了コード規約に従い、PreTo
 
 環境変数でスクリプトゲートのコマンドを上書きできます。
 
-| 変数        | 対象               | 例                        |
-| ----------- | ------------------ | ------------------------- |
-| `$LINT_CMD` | lint ゲート        | `LINT_CMD="eslint ."`     |
-| `$TYPE_CMD` | type-check         | `TYPE_CMD="tsc --noEmit"` |
-| `$UNIT_CMD` | test ゲート        | `UNIT_CMD="vitest run"`   |
-| `$TEST_CMD` | 全スクリプトゲート | レガシー単一ゲートモード  |
+| 変数              | 対象               | 例                              |
+| ----------------- | ------------------ | ------------------------------- |
+| `$GATES_LINT_CMD` | lint ゲート        | `GATES_LINT_CMD="eslint ."`     |
+| `$GATES_TYPE_CMD` | type-check         | `GATES_TYPE_CMD="tsc --noEmit"` |
+| `$GATES_UNIT_CMD` | test ゲート        | `GATES_UNIT_CMD="vitest run"`   |
+| `$GATES_TEST_CMD` | 全スクリプトゲート | 単一ゲートモード                |
 
-`$TEST_CMD` を設定すると、スクリプトゲートの検出がスキップされ、指定されたコマンドのみ実行されます（completion-gate.shとの後方互換）。
+`$GATES_TEST_CMD` を設定すると、スクリプトゲートの検出がスキップされ、指定されたコマンドのみ実行されます。`GATES_` プレフィックスにより、無関係な CI やプロジェクトの変数（例: 無印の `TEST_CMD=jest`）との衝突を防ぎます。
 
 ### 設定ファイルの解決
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Detected from `package.json` scripts. The package manager is auto-detected from 
 | type-check | `"test:type"` or `"typecheck"` | Independent                 |
 | test       | `"test:unit"` or `"test"`      | Skipped if type-check fails |
 
-When no lock file is found, script gates are silently skipped (fail-open). Environment variable overrides (`$LINT_CMD`, `$TYPE_CMD`, `$UNIT_CMD`) bypass auto-detection and run the specified command directly.
+When no lock file is found, script gates are silently skipped (fail-open). Environment variable overrides (`$GATES_LINT_CMD`, `$GATES_TYPE_CMD`, `$GATES_UNIT_CMD`) bypass auto-detection and run the specified command directly.
 
 ## Required Tools
 
@@ -270,14 +270,14 @@ The clone gate hashes the oxc AST of every `src/` file to find Type 1 (whitespac
 
 Override script gate commands with environment variables:
 
-| Variable    | Overrides        | Example                   |
-| ----------- | ---------------- | ------------------------- |
-| `$LINT_CMD` | lint gate        | `LINT_CMD="eslint ."`     |
-| `$TYPE_CMD` | type-check       | `TYPE_CMD="tsc --noEmit"` |
-| `$UNIT_CMD` | test gate        | `UNIT_CMD="vitest run"`   |
-| `$TEST_CMD` | all script gates | Legacy single-gate mode   |
+| Variable          | Overrides        | Example                         |
+| ----------------- | ---------------- | ------------------------------- |
+| `$GATES_LINT_CMD` | lint gate        | `GATES_LINT_CMD="eslint ."`     |
+| `$GATES_TYPE_CMD` | type-check       | `GATES_TYPE_CMD="tsc --noEmit"` |
+| `$GATES_UNIT_CMD` | test gate        | `GATES_UNIT_CMD="vitest run"`   |
+| `$GATES_TEST_CMD` | all script gates | Single-gate mode                |
 
-When `$TEST_CMD` is set, script gate detection is skipped and only the specified command runs (backwards compatibility with completion-gate.sh).
+When `$GATES_TEST_CMD` is set, script gate detection is skipped and only the specified command runs. The `GATES_` prefix keeps these overrides from colliding with unrelated CI or project variables such as a bare `TEST_CMD=jest`.
 
 ### Config Resolution
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
         .filter(|(_, g)| config.is_enabled(g.name))
         .collect();
 
-    // Legacy mode: $TEST_CMD set → single gate, skip script detection
+    // Single-gate mode: $GATES_TEST_CMD set → one gate, skip script detection
     let script_gates: Vec<_> = if let Some(ref test_cmd) = overrides.test_cmd {
         vec![tools::ScriptGate {
             name: "test",

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -127,11 +127,22 @@ pub struct EnvOverrides {
 
 impl EnvOverrides {
     pub fn from_env() -> Self {
+        Self::from_env_with(|key| env::var(key).ok())
+    }
+
+    /// Reads the command overrides through an injected getter so tests can
+    /// exercise the env-name contract without mutating process-global state
+    /// (`env::set_var` is `unsafe`, which this crate forbids). Override names
+    /// carry the `GATES_` prefix to avoid colliding with unrelated CI/project
+    /// vars (a bare `TEST_CMD=jest` would otherwise silently hijack the gate);
+    /// no bare fallback is read, so the collision cannot reappear (#95).
+    fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Self {
+        let cmd = |key: &str| get(key).filter(|s| !s.is_empty());
         Self {
-            lint_cmd: env::var("LINT_CMD").ok().filter(|s| !s.is_empty()),
-            type_cmd: env::var("TYPE_CMD").ok().filter(|s| !s.is_empty()),
-            unit_cmd: env::var("UNIT_CMD").ok().filter(|s| !s.is_empty()),
-            test_cmd: env::var("TEST_CMD").ok().filter(|s| !s.is_empty()),
+            lint_cmd: cmd("GATES_LINT_CMD"),
+            type_cmd: cmd("GATES_TYPE_CMD"),
+            unit_cmd: cmd("GATES_UNIT_CMD"),
+            test_cmd: cmd("GATES_TEST_CMD"),
             audit_dir: audit::default_dir(),
             snapshot_dir: audit::default_dir().map(|d| d.join("snapshots")),
         }
@@ -874,6 +885,41 @@ mod tests {
 
     fn no_overrides() -> EnvOverrides {
         EnvOverrides::default()
+    }
+
+    #[test]
+    fn from_env_reads_gates_prefixed_names() {
+        let overrides = EnvOverrides::from_env_with(|key| match key {
+            "GATES_LINT_CMD" => Some("gates-lint".into()),
+            "GATES_TYPE_CMD" => Some("gates-type".into()),
+            "GATES_UNIT_CMD" => Some("gates-unit".into()),
+            "GATES_TEST_CMD" => Some("gates-test".into()),
+            _ => None,
+        });
+        assert_eq!(overrides.lint_cmd.as_deref(), Some("gates-lint"));
+        assert_eq!(overrides.type_cmd.as_deref(), Some("gates-type"));
+        assert_eq!(overrides.unit_cmd.as_deref(), Some("gates-unit"));
+        assert_eq!(overrides.test_cmd.as_deref(), Some("gates-test"));
+    }
+
+    #[test]
+    fn from_env_ignores_bare_unprefixed_names() {
+        // A bare `TEST_CMD=jest` from unrelated CI must not hijack the gate (#95).
+        let overrides = EnvOverrides::from_env_with(|key| match key {
+            "LINT_CMD" | "TYPE_CMD" | "UNIT_CMD" | "TEST_CMD" => Some("hijack".into()),
+            _ => None,
+        });
+        assert_eq!(overrides.lint_cmd, None);
+        assert_eq!(overrides.type_cmd, None);
+        assert_eq!(overrides.unit_cmd, None);
+        assert_eq!(overrides.test_cmd, None);
+    }
+
+    #[test]
+    fn from_env_filters_empty_override_to_none() {
+        let overrides =
+            EnvOverrides::from_env_with(|key| (key == "GATES_LINT_CMD").then(String::new));
+        assert_eq!(overrides.lint_cmd, None);
     }
 
     const NPM: Option<&str> = Some("npm run");


### PR DESCRIPTION
## 概要と背景

スクリプトゲートのコマンドオーバーライド環境変数 (`LINT_CMD`/`TYPE_CMD`/`UNIT_CMD`/`TEST_CMD`) に `GATES_` プレフィックスを付与する。無印の変数名は無関係な CI/プロジェクトの環境変数と衝突し、特に `TEST_CMD=jest` がゲートコマンドを無言で乗っ取る欠陥があった。兄弟ツールの `GUARDRAILS_*`/`FORMATTER_*` 命名規約とも整合させる。

## 変更内容

- `src/tools.rs`: `EnvOverrides::from_env` が読む変数名を `GATES_LINT_CMD`/`GATES_TYPE_CMD`/`GATES_UNIT_CMD`/`GATES_TEST_CMD` へ rename。無印名のフォールバックは読まない (衝突再発を防ぐため)
- `src/tools.rs`: `from_env_with(get)` getter 注入シームを追加。`unsafe_code = forbid` 下で `env::set_var` を使わず環境変数名の契約をテスト可能にする
- `src/main.rs`: 単一ゲートモードのコメントを `$GATES_TEST_CMD` 基準へ更新
- `README.md` / `README.ja.md`: 環境変数表・本文を `GATES_` プレフィックスへ更新、衝突回避の説明を追記
- テスト3件追加: GATES_ 名の honor、無印名の無視 (#95 リグレッションガード)、空文字の None フィルタ

## 設計判断

- 後方互換で無印名をフォールバック読みする案は却下。乗っ取りバグを温存するため。リポジトリ・全兄弟リポジトリで set-site ゼロを確認済みで、v0.12.0 (pre-1.0 semver) ゆえ破壊的 rename を許容
- テストは `env::set_var` (edition 2024 で unsafe、本クレートは forbid) を避けるため getter 注入を採用。プロセスグローバル変更もシリアライズロックも不要

## テスト手順

1. `cargo test` → 256 passed (新規3件含む)
2. `GATES_LINT_CMD="eslint ." gates` → lint ゲートが上書きコマンドで実行される
3. `LINT_CMD="eslint ." gates` → 無印名は無視され自動検出にフォールバック

## 関連

- Closes #95

https://claude.ai/code/session_016sgb3rgG1482AxusuSTyuw