### PR TITLE
robustness/一貫性ギャップの解消: panic→70 未保証 / jscpd temp dir 予測可能 / color is_terminal / config fail-open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +102,18 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -114,6 +136,18 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litmus"
@@ -166,6 +200,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "owo-colors"
@@ -455,6 +495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +534,19 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -580,6 +639,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +711,21 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ path = "src/main.rs"
 serde = { version = "1", features = ["derive"] }
 serde_json = ">=1"
 regex = ">=1"
+# Secure temp dir for the jscpd report (CWE-377): random, O_EXCL-atomic name so
+# a predictable PID-based path can't be pre-created/symlinked in world-writable
+# $TMPDIR. Compile-time-only weight; runtime cost is one dir create per jscpd run.
+tempfile = ">=3"
 # litmus is a first-party git dependency with no semver releases. A bare git dep
 # floats to the default-branch HEAD on `cargo update`, which is a stability hazard
 # for a per-edit hook, so pin it by rev. The registry crates below (oxc/serde/regex)

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,8 +1,15 @@
 use std::env;
+use std::io::{IsTerminal, stderr};
 use std::sync::LazyLock;
 
 fn use_color() -> bool {
-    static COLOR: LazyLock<bool> = LazyLock::new(|| env::var_os("NO_COLOR").is_none());
+    // ANSI only when `NO_COLOR` is unset and stderr is a real terminal. The
+    // human-facing colored output (the gate summary) goes to stderr; under a
+    // hook both streams are pipes, so this also keeps escapes out of the block
+    // JSON `reason` on stdout, which an agent reads as plain text. Mirrors
+    // guardrails `io/color.rs`.
+    static COLOR: LazyLock<bool> =
+        LazyLock::new(|| env::var_os("NO_COLOR").is_none() && stderr().is_terminal());
     *COLOR
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,14 @@ impl GatesConfig {
         }
     }
 
+    /// Load `.claude/tools.json`. Fail-open by design: a missing file, an
+    /// unreadable file, or invalid JSON falls back to `Self::default()` (every
+    /// gate enabled) after surfacing the cause on stderr. A broken config must
+    /// widen detection, never silently disable quality enforcement — disabling
+    /// gates on error would be a silent failure that lets violations through.
+    /// This diverges intentionally from guardrails/formatter, which fail-closed,
+    /// because gates is the post-edit audit half and a missing audit is the
+    /// worse outcome than a noisy one.
     pub fn load(project_dir: &Path) -> Self {
         let path = project_dir.join(TOOLS_CONFIG_FILE);
         let content = match fs::read_to_string(&path) {

--- a/src/hook_exit.rs
+++ b/src/hook_exit.rs
@@ -12,22 +12,26 @@
 //! | 1    | `Advisory`   | advisory failure (severity=warn)     | no (reserved)      |
 //! | 2    | `Blocking`   | blocking failure; child gate failed  | no (→ stdout JSON + exit 0) |
 //! | 64   | `InputError` | usage error / malformed hook input   | yes (CLI usage)    |
-//! | 70   | `Internal`   | internal panic / spawn failure       | no (fail-open → exit 0) |
+//! | 70   | `Internal`   | orchestration panic (caught)         | yes (`main` `catch_unwind`) |
 //!
-//! Only `InputError` (64) reaches a real process exit on the live paths, and
-//! only on direct-CLI usage errors (`gates a b c`, a non-directory argument) —
-//! the hook invocation (`gates`, dir = cwd) never trips them. On the hook path,
-//! `Blocking` is converted to stdout JSON + exit 0 by the caller, and any
-//! `Internal` fault is swallowed by fail-open (the gate is skipped, not raised).
-//! `Advisory` is reserved: every gate today is blocking. `EX_IOERR` (74) on the
-//! `gates show` path is an ADR-0060 I/O code orthogonal to this enum and lives
-//! as a separate constant.
+//! Two codes reach a real process exit on the live paths. `InputError` (64) on
+//! direct-CLI usage errors (`gates a b c`, a non-directory argument) — the hook
+//! invocation (`gates`, dir = cwd) never trips them. `Internal` (70) when an
+//! orchestration-layer panic (config load, the block `json!`, reporter
+//! formatting) unwinds to `main`'s `catch_unwind`; gate-thread panics never get
+//! here, as `join_or_skip` already maps them to `skipped`. Per Group 3 a non-2
+//! exit stays non-blocking, so 70 surfaces the fault without breaking fail-open.
+//! On the hook path `Blocking` is converted to stdout JSON + exit 0 by the
+//! caller. `Advisory` (1) is reserved: every gate today is blocking. `EX_IOERR`
+//! (74) on the `gates show` path is an ADR-0060 I/O code orthogonal to this enum
+//! and lives as a separate constant.
 
-// `Pass`, `Advisory`, `Blocking`, and `Internal` are reserved at the type level
-// per issue #18: the hook wrapper keeps exit 0 for the decision surface and
-// fail-open swallows internal faults, so only `InputError` reaches a live exit
-// today. The full Group 3 mapping is kept so a future hook-spec change can
-// switch the surface without redefining the type.
+// `Pass`, `Advisory`, and `Blocking` are reserved at the type level per issue
+// #18: the hook wrapper keeps exit 0 for the decision surface, so `Pass` (0) and
+// `Blocking` (2) never reach a live exit and `Advisory` (1) has no producer yet.
+// `InputError` and `Internal` are live (see the module doc). The full Group 3
+// mapping is kept so a future hook-spec change can switch the surface without
+// redefining the type.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookExitCode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod traverse;
 
 use std::env;
 use std::io::{self, Write};
+use std::panic::{self, AssertUnwindSafe};
 use std::path::Path;
 use std::process;
 use std::thread;
@@ -423,7 +424,21 @@ fn run_show(args: &[String]) -> i32 {
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    process::exit(dispatch(&args));
+    process::exit(dispatch_or_internal(|| dispatch(&args)));
+}
+
+/// Run `dispatch` under `catch_unwind`, mapping a panic to `Internal` (70). Gate
+/// **threads** are already isolated by `join_or_skip` (panic → `skipped`, the
+/// run continues), so only an orchestration-layer panic — config load, the block
+/// `json!`, reporter formatting — unwinds to here. The whole hook cannot produce
+/// a decision in that case, so surface it as `EX_SOFTWARE` rather than letting
+/// Rust's default exit 101 leak; per ADR-0066 Group 3 any non-2 exit is still
+/// non-blocking, so fail-open is preserved. This is the only live constructor of
+/// `HookExitCode::Internal`. `AssertUnwindSafe` is sound here: on a panic the
+/// process exits, so no caller observes half-mutated state across the boundary.
+fn dispatch_or_internal<F: FnOnce() -> i32>(run: F) -> i32 {
+    panic::catch_unwind(AssertUnwindSafe(run))
+        .unwrap_or_else(|_| i32::from(HookExitCode::Internal.code()))
 }
 
 /// Route argv to a subcommand and return the process exit code. Extracted from
@@ -517,6 +532,22 @@ mod tests {
         assert!(results.iter().all(runner::ToolResult::is_skipped));
         assert_eq!(results[0].name, "circular");
         assert_eq!(results[1].name, "coupling");
+    }
+
+    // An orchestration-layer panic (not a gate thread) unwinds to `main`'s
+    // `catch_unwind` and exits `Internal` (70), surfacing the fault instead of
+    // leaking Rust's default exit 101. The non-panicking path returns its code
+    // verbatim. The default panic hook prints one "panicked at" line to stderr
+    // here, matching the existing thread-panic tests; it is left in place rather
+    // than muted, which would install a process-global hook and swallow the
+    // diagnostics of any other test panicking in parallel.
+    #[test]
+    fn dispatch_or_internal_maps_panic_to_seventy() {
+        let panicked = dispatch_or_internal(|| panic!("orchestration blew up"));
+        let normal = dispatch_or_internal(|| 64);
+        assert_eq!(panicked, i32::from(HookExitCode::Internal.code()));
+        assert_eq!(panicked, 70);
+        assert_eq!(normal, 64);
     }
 
     fn setup_project(gates_json: &str, files: &[&str]) -> TempDir {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -17,7 +17,6 @@ use std::io;
 use std::iter;
 use std::panic::resume_unwind;
 use std::path::{Path, PathBuf};
-use std::process;
 use std::process::Command;
 use std::thread;
 
@@ -724,21 +723,26 @@ pub fn run_jscpd(
         return ToolResult::skipped("jscpd");
     }
 
-    let out_dir = env::temp_dir().join(format!("gates-jscpd-{}", process::id()));
-    // Clear any report left by a prior run whose cleanup failed before this PID
-    // was reused, so a stale report is never read as the current run's result.
-    let _ = fs::remove_dir_all(&out_dir);
-    if let Err(e) = fs::create_dir_all(&out_dir) {
-        eprintln!("gates: jscpd temp dir create failed: {e}");
-        return ToolResult::skipped("jscpd");
-    }
+    // A fresh, randomly-named temp dir per run (tempfile, CWE-377): an
+    // unprivileged process cannot predict the path to pre-create a symlink and
+    // hijack the report read/write. A unique name per run also means no stale
+    // report can survive across runs, and `TempDir`'s Drop removes the dir when
+    // this function returns.
+    let temp = match tempfile::tempdir() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("gates: jscpd temp dir create failed: {e}");
+            return ToolResult::skipped("jscpd");
+        }
+    };
+    let out_dir = temp.path();
 
     let bin = resolve::resolve_bin("jscpd", &project.root);
     let mut cmd = Command::new(&bin);
     cmd.arg(&project.root)
         .args(["--reporters", "json"])
         .arg("--output")
-        .arg(&out_dir)
+        .arg(out_dir)
         .arg("--silent")
         .args(["--min-lines", &min_lines.to_string()])
         .args(["--min-tokens", &min_tokens.to_string()]);
@@ -748,7 +752,9 @@ pub fn run_jscpd(
     cmd.current_dir(&project.root);
 
     let result = run_command("jscpd", cmd, GATE_TIMEOUT);
-    let outcome = if result.is_skipped() {
+    // `temp` (and thus `out_dir`) stays alive through this tail expression, then
+    // its Drop removes the temp dir as the function returns.
+    if result.is_skipped() {
         // Binary missing or timed out: fail-open.
         result
     } else {
@@ -766,12 +772,7 @@ pub fn run_jscpd(
                 ToolResult::skipped("jscpd")
             }
         }
-    };
-
-    if let Err(e) = fs::remove_dir_all(&out_dir) {
-        eprintln!("gates: jscpd temp dir cleanup failed: {e}");
     }
-    outcome
 }
 
 /// Distinct banner prepended to a downgraded type gate's output so the human reads
@@ -858,13 +859,6 @@ mod tests {
     use crate::test_utils::{TempDir, link_fake_bin};
     use std::fs;
     use std::path::PathBuf;
-    use std::sync::{Mutex, PoisonError};
-
-    /// `run_jscpd` derives its temp output dir from the process PID, so the three
-    /// end-to-end tests below share one dir. Serialize them so one test's report
-    /// is never read (or wiped) by another running concurrently.
-    static JSCPD_RUN_LOCK: Mutex<()> = Mutex::new(());
-
     fn test_project(has_pkg: bool, has_ts: bool) -> ProjectInfo {
         ProjectInfo {
             root: PathBuf::from("/tmp/nonexistent"),
@@ -1879,9 +1873,6 @@ test("uppercases the provided first name", () => {
     // T-638: end-to-end — jscpd writes a report above threshold, gate warns.
     #[test]
     fn jscpd_warns_from_written_report() {
-        let _guard = JSCPD_RUN_LOCK
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
         let body = r#"{"statistics":{"total":{"percentage":25.0}},"duplicates":[{"lines":7,"firstFile":{"name":"a.ts"},"secondFile":{"name":"b.ts"}}]}"#;
         let (_tmp, project) = jscpd_project_with_fake_bin(body);
         let result = run_jscpd(&project, 5, 50, 10.0, false, &[]);
@@ -1892,39 +1883,9 @@ test("uppercases the provided first name", () => {
     // T-639: a binary that writes no report file skips (fail-open).
     #[test]
     fn jscpd_skips_when_report_missing() {
-        let _guard = JSCPD_RUN_LOCK
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
         let (_tmp, project) = jscpd_project_with_fake_bin("");
         let result = run_jscpd(&project, 5, 50, 10.0, false, &[]);
         assert!(result.is_skipped(), "missing report should skip, not block");
-    }
-
-    // T-640: a stale report left in the temp dir (prior run's cleanup failed,
-    // then PID reused) is not read as the current run's result. run_jscpd must
-    // start from a clean output dir.
-    #[test]
-    fn jscpd_ignores_stale_report_from_prior_run() {
-        let _guard = JSCPD_RUN_LOCK
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
-        let out_dir = env::temp_dir().join(format!("gates-jscpd-{}", process::id()));
-        fs::create_dir_all(&out_dir).unwrap();
-        fs::write(
-            out_dir.join("jscpd-report.json"),
-            r#"{"statistics":{"total":{"percentage":99.0}},"duplicates":[]}"#,
-        )
-        .unwrap();
-
-        // The current run's binary writes no report (finds nothing / fails to emit).
-        let (_tmp, project) = jscpd_project_with_fake_bin("");
-        let result = run_jscpd(&project, 5, 50, 10.0, false, &[]);
-
-        assert!(
-            result.is_skipped(),
-            "stale report must not be read as the current run: {}",
-            result.output()
-        );
     }
 
     // The default ignore list keeps jscpd out of the `.git` directory, whose
@@ -1932,9 +1893,6 @@ test("uppercases the provided first name", () => {
     // groups. Verify the glob reaches jscpd's `--ignore` argument end to end.
     #[test]
     fn jscpd_default_ignore_excludes_git_dir() {
-        let _guard = JSCPD_RUN_LOCK
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
         let tmp = TempDir::new("jscpd-args");
         fs::write(tmp.join("package.json"), "{}").unwrap();
         link_fake_bin(&tmp, "jscpd", "jscpd-record-args");


### PR DESCRIPTION
## 概要と目的

姉妹 hook (guardrails / litmus / formatter) と比べた gates の robustness / 一貫性ギャップ 4 件 (#96) を解消する。いずれも単独では P2 だが、内部障害時の挙動と temp file の安全性を姉妹 hook の水準に揃える。

## 変更点

- panic→70: `main` の `dispatch` を `catch_unwind` で包み、orchestration 層 (config load / block `json!` / reporter formatting) の panic を exit 70 (`HookExitCode::Internal`) にマップ。dead だった `Internal` を live 化。gate thread の panic は従来どおり `join_or_skip` が `skipped` に隔離する
- jscpd temp dir: PID 命名の予測可能パスを `tempfile::tempdir()` (random / O_EXCL / 0700) に変更し CWE-377 (symlink-swap / TOCTOU) を解消。unique dir 化で stale report が構造的に不可能になり、それを守っていた T-640 と `JSCPD_RUN_LOCK` を削除 (`TempDir` Drop が cleanup を担う)
- color: `use_color()` に `stderr().is_terminal()` を追加。pipe / redirect 先や hook 経路 (両 stream が pipe) で ANSI escape を出さない。block JSON `reason` からも escape が消え、agent が plain text で読む
- config fail-open: `load()` の意図的 fail-open (error → 全 gate 有効) を doc 化 (挙動変更なし)

## 設計判断

- panic 時 exit は 0 (silent swallow) でなく 70 (surface) を選択。Group 3 で 2 以外の非ゼロは非ブロッキングのため fail-open を保ったまま障害を可視化でき、姉妹 3 repo と一致する。OUTCOME.md / `hook_exit.rs` の「70 は予約」契約をこの 1 経路で live に更新
- config は意図的に fail-closed の姉妹と分岐。broken config で監査が消える方が、全 gate 有効の noisy な fail-open より悪いという判断

## テスト方法

1. `cargo test` → 256 tests green (新規 `dispatch_or_internal_maps_panic_to_seventy` 含む)
2. `cargo clippy --all-targets` → 0 warnings
3. reviewer-security / reviewer-rust の独立レビューで 0 critical、RU1 (panic test の global hook) 解消済み

## 関連

- Closes #96

https://claude.ai/code/session_016sgb3rgG1482AxusuSTyuw