### PR TITLE
fix: nested-package monorepo で config 所有パッケージにゲートを fan-out (#102)

### DIFF
--- a/docs/decisions/0007-fan-package-scoped-gates-out-over-monorepo-members.md
+++ b/docs/decisions/0007-fan-package-scoped-gates-out-over-monorepo-members.md
@@ -1,0 +1,60 @@
+---
+status: "accepted"
+date: 2026-06-30
+decision-makers: [thkt]
+---
+
+# Fan package-scoped gates out over monorepo members
+
+## Context and Problem Statement
+
+`ProjectInfo::detect` resolves a single `root` to the nearest `.git` ancestor (project.rs:52-57), and every gate runs with `current_dir(&project.root)` while its `condition` probes config files only at that root (tools.rs:843, GATES conditions tools.rs:69-117). In a monorepo where `.git` sits at the outer container and the real `tsconfig.json`/`src` lives one level down (`packages/foo`), the root owns no tsconfig and no `src/`, so `has_tsconfig` is false and `run_graph_gates` early-returns `Skipped` (tools.rs:458-468). The gate silently skips the package that owns the code (#102): tsgo, oxlint, circular, and coupling never see the nested package. This is a false pass, not a fail-open skip — the machinery could have run, it just looked in the wrong directory.
+
+## Decision Drivers
+
+- A nested-package monorepo must get the same gate coverage as a flat repo, with no config change required from the user
+- Non-monorepo repos (the common case) must keep byte-identical behavior — zero regression risk
+- The hook runs on every edit, so discovery cannot blow the latency budget on a deep tree
+- Gates that already resolve the whole workspace from the root (knip) or from their own config (depcruise) must not be double-run
+
+## Considered Options
+
+- Fan the package-scoped gates out over discovered member directories, root-or-members by an either/or discriminator (this ADR)
+- Always run both the root and every discovered package (union)
+- Make each gate walk down to find its own config at run time
+- Require the user to point gates at each package via config
+
+## Decision Outcome
+
+Chosen option: `ProjectInfo::package_targets` (project.rs:68-79) returns the directories the package-scoped gates run against, by an either/or discriminator. When the git root directly owns analyzable code (`has_tsconfig` or a root `src/`), the root is the sole target — today's behavior, so every non-monorepo repo is unchanged. Otherwise the root is a container and discovery descends (bounded `MAX_PACKAGE_DEPTH = 4`, excluding dependency/build dirs) to the member directories that own a `package.json` or `tsconfig.json`, stopping descent once a package matches so a member's own fixtures are not promoted to separate targets (project.rs:90-116). The root and the members are never both run — union would double-report.
+
+Exactly four gates fan out, selected by where their scope is anchored:
+
+- tsgo, oxlint — anchored on the in-directory `tsconfig.json`, marked `per_package: true` (tools.rs:88, 103). They run once per member that owns a tsconfig; a member without one self-skips via the existing `condition`.
+- circular, coupling — read each member's own `src/` dependency graph, fanned out in `run_with_overrides` (main.rs:207-231) building one graph per member.
+
+Three gates stay root-anchored: knip resolves workspaces from the root manifest in one pass, depcruise is config-driven, and litmus already uses a recursive `**/*.test.ts` glob from the root (tools.rs:390) that covers every member, so per-package would double-report.
+
+Per-member results are labeled with the member directory relative to the root (`ToolResult::scoped`, runner.rs:98-105, applied at the fan-out site via `scope_result`, main.rs:128-137). Two members that each fail `circular` render the same `✗ circular` header with bodies whose paths are relative to each member's own `src/`, so without the label they collide; the label is added only when the target differs from the root, keeping self-contained output byte-identical.
+
+### Consequences
+
+- Good, because a nested-package monorepo gets full coverage with no user config, closing the #102 false pass
+- Good, because the either/or discriminator makes the non-monorepo path a single `[root]` target, so the 261 pre-existing tests pass unchanged — zero regression
+- Good, because one thread per gate loops its target list, so the spawned-thread count stays one-per-gate regardless of member count
+- Bad, because a root that owns a tsconfig and also nests packages runs only at the root: the discriminator treats a self-contained root as terminal, so members below an analyzable root are out of scope (documented limitation, not yet a real layout)
+- Bad, because discovery is a per-edit downward `read_dir` walk bounded by depth and excluded dirs rather than reading the workspace manifest, so a member outside `MAX_PACKAGE_DEPTH` or under an excluded name is missed
+
+### Confirmation
+
+`project::tests` pin discovery: self-contained tsconfig/src roots return `[root]` (the zero-regression invariant), the #102 container layout discovers the tsconfig-owning member, the bug-reproduction test asserts a root-anchored `run_graph_gates` skips while the fan-out detects the cycle, and `node_modules` packages are excluded. `main::tests` pin the orchestration end to end: tsgo and circular fan out into `packages/app` and label the failure `[packages/app]`, two sibling members each rendering their own `✗ circular` block labeled `[packages/a]` and `[packages/b]` (the disambiguation `scoped` exists for), while a self-contained root failure carries no label.
+
+## More Information
+
+### Quality Attributes
+
+Coverage of nested packages is chosen without sacrificing the zero-regression guarantee for flat repos: the either/or discriminator, not a union, is what buys both. The cost is paid in discovery's heuristic reach (depth bound, excluded names) rather than in the common-case path.
+
+### Trade-offs
+
+Downward `read_dir` discovery vs reading the workspace manifest: the manifest (pnpm-workspace.yaml, `workspaces` globs) would be authoritative but adds a parser and per-ecosystem format handling. The bounded walk reuses the existing `EXCLUDED_DIRS` downward-walk pattern (depgraph.rs, snapshot.rs) and finds shallowly-nested members, accepting that a member outside the bound is missed. Either/or vs union: union would cover the analyzable-root-with-nested-members layout this ADR leaves out, but double-reports every flat repo's root and breaks the byte-identical invariant, so the rarer layout is deferred until it appears.

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,22 @@ fn join_into(results: &mut Vec<runner::ToolResult>, (fallback, handle): GateTask
     results.extend(runner::join_or_skip(handle.join(), &fallback));
 }
 
+/// Label a per-package result with its directory relative to the project root
+/// so identically-named failures from different packages stay distinguishable
+/// (#102 fan-out). A self-contained project's only target is the root itself,
+/// whose relative path is empty, so it is returned unlabeled — keeping the
+/// output byte-identical to a root-only run for every non-monorepo repo.
+fn scope_result(
+    result: runner::ToolResult,
+    target_root: &Path,
+    project_root: &Path,
+) -> runner::ToolResult {
+    match target_root.strip_prefix(project_root) {
+        Ok(rel) if !rel.as_os_str().is_empty() => result.scoped(&rel.display().to_string()),
+        _ => result,
+    }
+}
+
 fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Option<String> {
     let config = config::GatesConfig::load(project_dir);
 
@@ -128,6 +144,12 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
     }
 
     let project = project::ProjectInfo::detect(project_dir);
+
+    // The package-scoped gates run against these targets. For a self-contained
+    // project this is just `[root]` (today's behavior); for a monorepo container
+    // whose `.git` sits above the real packages it is the discovered members
+    // (#102), so a tsconfig nested one level down is no longer skipped.
+    let targets = project.package_targets();
 
     let enabled: Vec<_> = tools::GATES
         .iter()
@@ -155,11 +177,25 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
     let mut tasks: Vec<GateTask> = Vec::new();
 
     for (idx, gate) in enabled {
-        let p = project.clone();
+        // A per-package gate runs against every discovered target; a
+        // root-anchored gate (knip, depcruise) runs against the root alone.
+        // Both go through one thread that loops its target list, so the spawned
+        // thread count stays one-per-gate regardless of package count.
+        let gate_targets: Vec<project::ProjectInfo> = if gate.per_package {
+            targets.clone()
+        } else {
+            vec![project.clone()]
+        };
+        let root = project.root.clone();
         let name = gate.name;
         tasks.push((
             vec![name],
-            thread::spawn(move || vec![tools::run_gate(&tools::GATES[idx], &p)]),
+            thread::spawn(move || {
+                gate_targets
+                    .iter()
+                    .map(|t| scope_result(tools::run_gate(&tools::GATES[idx], t), &t.root, &root))
+                    .collect()
+            }),
         ));
     }
 
@@ -169,7 +205,10 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
     }
 
     if circular_enabled || coupling_enabled {
-        let p = project.clone();
+        // circular/coupling read each package's own `src/` dependency graph, so
+        // they fan out over the same targets and build one graph per package.
+        let graph_targets = targets.clone();
+        let root = project.root.clone();
         let ca_threshold = config.coupling.ca_threshold;
         let mut fallback = Vec::new();
         if circular_enabled {
@@ -181,7 +220,15 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
         tasks.push((
             fallback,
             thread::spawn(move || {
-                tools::run_graph_gates(&p, circular_enabled, coupling_enabled, ca_threshold)
+                graph_targets
+                    .iter()
+                    .flat_map(|t| {
+                        tools::run_graph_gates(t, circular_enabled, coupling_enabled, ca_threshold)
+                            .into_iter()
+                            .map(|r| scope_result(r, &t.root, &root))
+                            .collect::<Vec<_>>()
+                    })
+                    .collect()
             }),
         ));
     }
@@ -1310,5 +1357,166 @@ mod tests {
     #[test]
     fn usage_errors_use_ex_usage_64() {
         assert_eq!(ex_usage(), 64);
+    }
+
+    // #102: a monorepo container (root holds the workspace manifest but owns no
+    // `src/` or `tsconfig.json`) must fan a per-package table gate out into the
+    // member that owns the config. tsgo, anchored at the git root today, would
+    // see no root tsconfig and skip; the fan-out runs it inside `packages/app`
+    // and labels the failure with that package so it is attributable.
+    #[test]
+    fn tsgo_fans_out_into_nested_package_and_labels_scope() {
+        let tmp = setup_project(r#"{"gates":{"tsgo":true}}"#, &["package.json"]);
+        let pkg = tmp.join("packages/app");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(pkg.join("package.json"), "{}").unwrap();
+        fs::write(pkg.join("tsconfig.json"), "{}").unwrap();
+        // A fake tsgo that exits nonzero, resolved from the package's own
+        // node_modules/.bin since the gate runs with the package as its root.
+        test_utils::link_fake_bin(&pkg, "tsgo", "knip-unused-export");
+
+        let block = run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                audit_dir: Some(tmp.join("audit")),
+                ..Default::default()
+            },
+        )
+        .expect("the nested package's tsgo failure must block");
+        let plain = color::strip_ansi(&block);
+        assert!(
+            plain.contains("tsgo"),
+            "tsgo must fire in the package: {plain}"
+        );
+        assert!(
+            plain.contains("[packages/app]"),
+            "the failure must be labeled with the owning package: {plain}"
+        );
+    }
+
+    // #102 companion for the graph gates: circular reads each package's own
+    // `src/` graph, so in a container it fans out and detects a cycle living
+    // inside `packages/app/src` that a root-anchored run (no root `src/`) skips.
+    #[test]
+    fn circular_fans_out_into_nested_package_and_labels_scope() {
+        let tmp = setup_project(r#"{"gates":{"circular":true}}"#, &["package.json"]);
+        let src = tmp.join("packages/app/src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(tmp.join("packages/app/package.json"), "{}").unwrap();
+        fs::write(
+            src.join("a.ts"),
+            "import { b } from './b';\nexport const a = 1;\n",
+        )
+        .unwrap();
+        fs::write(
+            src.join("b.ts"),
+            "import { a } from './a';\nexport const b = 2;\n",
+        )
+        .unwrap();
+
+        let block = run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                audit_dir: Some(tmp.join("audit")),
+                ..Default::default()
+            },
+        )
+        .expect("the nested cycle must block");
+        let plain = color::strip_ansi(&block);
+        assert!(
+            plain.contains("circular"),
+            "the circular gate must fire: {plain}"
+        );
+        assert!(
+            plain.contains("[packages/app]"),
+            "the failure must be labeled with the owning package: {plain}"
+        );
+    }
+
+    // #102 multi-member case: two sibling packages each own a cycle. The
+    // fan-out must discover both, run the graph gate per member, and label each
+    // failure with its own package so the two `circular` blocks are
+    // distinguishable instead of colliding under one unlabeled header. This is
+    // the scenario `scoped` and the `dirs.sort()` ordering exist for; the
+    // single-member tests above never exercise the disambiguation.
+    #[test]
+    fn circular_fans_out_into_two_members_labeling_each() {
+        let tmp = setup_project(r#"{"gates":{"circular":true}}"#, &["package.json"]);
+        for member in ["a", "b"] {
+            let src = tmp.join(format!("packages/{member}/src"));
+            fs::create_dir_all(&src).unwrap();
+            fs::write(tmp.join(format!("packages/{member}/package.json")), "{}").unwrap();
+            fs::write(
+                src.join("a.ts"),
+                "import { b } from './b';\nexport const a = 1;\n",
+            )
+            .unwrap();
+            fs::write(
+                src.join("b.ts"),
+                "import { a } from './a';\nexport const b = 2;\n",
+            )
+            .unwrap();
+        }
+
+        let block = run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                audit_dir: Some(tmp.join("audit")),
+                ..Default::default()
+            },
+        )
+        .expect("both nested cycles must block");
+        let plain = color::strip_ansi(&block);
+        assert!(
+            plain.contains("[packages/a]"),
+            "member a's failure must be labeled: {plain}"
+        );
+        assert!(
+            plain.contains("[packages/b]"),
+            "member b's failure must be labeled: {plain}"
+        );
+        assert_eq!(
+            plain.matches("✗ circular").count(),
+            2,
+            "each member must render its own circular block: {plain}"
+        );
+    }
+
+    // The self-contained-root invariant at the orchestration layer: a project
+    // that owns its own `src/` runs the graph gate at the root and emits no
+    // package label, so output stays byte-identical to the pre-#102 behavior.
+    #[test]
+    fn self_contained_root_failure_carries_no_scope_label() {
+        let tmp = setup_project(r#"{"gates":{"circular":true}}"#, &["package.json"]);
+        let src = tmp.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            src.join("a.ts"),
+            "import { b } from './b';\nexport const a = 1;\n",
+        )
+        .unwrap();
+        fs::write(
+            src.join("b.ts"),
+            "import { a } from './a';\nexport const b = 2;\n",
+        )
+        .unwrap();
+
+        let block = run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                audit_dir: Some(tmp.join("audit")),
+                ..Default::default()
+            },
+        )
+        .expect("the root cycle must block");
+        let plain = color::strip_ansi(&block);
+        assert!(
+            plain.contains("circular"),
+            "the circular gate must fire: {plain}"
+        );
+        assert!(
+            !plain.contains('['),
+            "a self-contained root must not label its output: {plain}"
+        );
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,5 +1,26 @@
 use crate::traverse;
+use std::fs;
 use std::path::{Path, PathBuf};
+
+/// Directory names package discovery never descends into: dependencies, VCS,
+/// build output, and coverage/next caches cannot own a first-party package
+/// target. Extends the list `depgraph`/`snapshot` apply to their own downward
+/// walks with the cache dirs that commonly hold copied `package.json` fixtures.
+const EXCLUDED_DIRS: &[&str] = &[
+    "node_modules",
+    ".git",
+    "dist",
+    "build",
+    "target",
+    "coverage",
+    ".next",
+];
+
+/// How many directory levels below the git root package discovery descends. A
+/// monorepo nests its members shallowly (`packages/foo`, `apps/bar/ui`), so a
+/// small bound finds them while keeping a pathological tree from blowing the
+/// hook's latency budget.
+const MAX_PACKAGE_DEPTH: usize = 4;
 
 #[derive(Debug, Clone)]
 pub struct ProjectInfo {
@@ -11,11 +32,18 @@ pub struct ProjectInfo {
 impl ProjectInfo {
     pub fn detect(dir: &Path) -> Self {
         let root = Self::find_root(dir);
-        let has_package_json = root.join("package.json").exists();
-        let has_tsconfig = root.join("tsconfig.json").exists();
+        Self::for_dir(root)
+    }
 
+    /// Build a `ProjectInfo` rooted at `dir` without re-running the git-root
+    /// walk. `dir` is taken as the project root verbatim, so every gate's
+    /// `current_dir` and config-file probe target that directory. Used both for
+    /// the git-root project (`detect`) and for each discovered package target.
+    fn for_dir(dir: PathBuf) -> Self {
+        let has_package_json = dir.join("package.json").exists();
+        let has_tsconfig = dir.join("tsconfig.json").exists();
         Self {
-            root,
+            root: dir,
             has_package_json,
             has_tsconfig,
         }
@@ -27,6 +55,64 @@ impl ProjectInfo {
         })
         .unwrap_or_else(|| start.to_path_buf())
     }
+
+    /// The projects the package-scoped gates (tsgo, oxlint, circular, coupling)
+    /// run against. When the git root directly owns analyzable code — its own
+    /// `tsconfig.json` or `src/` — the root is the single target, which is the
+    /// behavior every non-monorepo repo already gets. Otherwise the root is a
+    /// monorepo container whose `.git` sits above the real packages (the issue
+    /// #102 layout: outer `.git`, inner `packages/foo/tsconfig.json`), so the
+    /// targets are the member package directories discovered beneath it. Each
+    /// gate's own condition still decides per target whether it runs, so a
+    /// package with no tsconfig skips the type gate exactly as before.
+    pub fn package_targets(&self) -> Vec<ProjectInfo> {
+        if self.has_tsconfig || self.root.join("src").is_dir() {
+            return vec![self.clone()];
+        }
+        let mut dirs = Vec::new();
+        discover_packages(&self.root, MAX_PACKAGE_DEPTH, &mut dirs);
+        // `read_dir` yields entries in filesystem order, which varies across
+        // platforms; sort so the gate output and audit log read the same run to
+        // run.
+        dirs.sort();
+        dirs.into_iter().map(Self::for_dir).collect()
+    }
+}
+
+/// Collect directories beneath `dir` that own a package boundary marker
+/// (`package.json` or `tsconfig.json`), descending at most `depth` levels and
+/// never into dependency/build directories. Descent stops once a directory
+/// matches: a package's own fixtures or examples (which carry their own
+/// `package.json`) are not promoted to separate targets, and workspace members
+/// sit one level apart so this still finds every member. `src/` is deliberately
+/// not a marker here — a bare `src/` with no manifest is not a distinct package,
+/// and the self-contained-root case is already handled by `package_targets`.
+fn discover_packages(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+    if depth == 0 {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if EXCLUDED_DIRS.contains(&name) {
+            continue;
+        }
+        if is_package_dir(&path) {
+            out.push(path);
+        } else {
+            discover_packages(&path, depth - 1, out);
+        }
+    }
+}
+
+fn is_package_dir(dir: &Path) -> bool {
+    dir.join("package.json").exists() || dir.join("tsconfig.json").exists()
 }
 
 #[cfg(test)]
@@ -90,5 +176,137 @@ mod tests {
         let info = ProjectInfo::detect(&subdir);
         assert!(info.has_package_json);
         assert_eq!(info.root, *tmp);
+    }
+
+    // A root that directly owns its tsconfig is a self-contained project: the
+    // package-scoped gates target the root alone, exactly as before #102. This
+    // pins the "zero behavior change for non-monorepo repos" invariant.
+    #[test]
+    fn self_contained_tsconfig_root_targets_only_itself() {
+        let tmp = TempDir::new("self-contained-ts");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        fs::write(tmp.join("tsconfig.json"), "{}").unwrap();
+        fs::create_dir_all(tmp.join("packages/app")).unwrap();
+        fs::write(tmp.join("packages/app/tsconfig.json"), "{}").unwrap();
+
+        let targets = ProjectInfo::detect(&tmp).package_targets();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].root, *tmp);
+    }
+
+    // Same invariant via the `src/` anchor: a root that owns `src/` runs at the
+    // root and does not fan out into nested packages.
+    #[test]
+    fn self_contained_src_root_targets_only_itself() {
+        let tmp = TempDir::new("self-contained-src");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        fs::create_dir_all(tmp.join("src")).unwrap();
+        fs::create_dir_all(tmp.join("packages/app")).unwrap();
+        fs::write(tmp.join("packages/app/package.json"), "{}").unwrap();
+
+        let targets = ProjectInfo::detect(&tmp).package_targets();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].root, *tmp);
+    }
+
+    // The #102 layout: the git root is a container (package.json workspaces
+    // manifest, no root tsconfig/src) and the real package owns the tsconfig.
+    // Discovery descends to that package so its target carries the tsconfig the
+    // root lacks.
+    #[test]
+    fn nested_monorepo_targets_the_tsconfig_owning_package() {
+        let tmp = TempDir::new("nested-ts");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        fs::write(tmp.join("package.json"), "{}").unwrap();
+        let pkg = tmp.join("packages/app");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(pkg.join("package.json"), "{}").unwrap();
+        fs::write(pkg.join("tsconfig.json"), "{}").unwrap();
+
+        let root = ProjectInfo::detect(&tmp);
+        assert!(!root.has_tsconfig, "the container root owns no tsconfig");
+
+        let targets = root.package_targets();
+        let app = targets
+            .iter()
+            .find(|t| t.root == pkg)
+            .expect("packages/app must be discovered as a target");
+        assert!(
+            app.has_tsconfig,
+            "the package target carries its own tsconfig"
+        );
+    }
+
+    // Bug reproduction (#102): in a container monorepo the circular gate must
+    // detect a cycle that lives inside a package's `src/`. Today the gate is
+    // anchored at the git root, which owns no `src/`, so the cycle is skipped and
+    // goes undetected — this test fails until discovery fans the gate out to the
+    // package that owns the `src/`.
+    #[test]
+    fn circular_gate_detects_cycle_inside_nested_package() {
+        let tmp = TempDir::new("nested-circular");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        fs::write(tmp.join("package.json"), "{}").unwrap();
+        let pkg = tmp.join("packages/app");
+        let src = pkg.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(pkg.join("package.json"), "{}").unwrap();
+        fs::write(
+            src.join("a.ts"),
+            "import { b } from './b';\nexport const a = 1;\n",
+        )
+        .unwrap();
+        fs::write(
+            src.join("b.ts"),
+            "import { a } from './a';\nexport const b = 2;\n",
+        )
+        .unwrap();
+
+        let root = ProjectInfo::detect(&tmp);
+        // The git root owns no `src/`, so a root-anchored run skips the gate —
+        // documenting the pre-fix behavior the bug report describes.
+        let at_root = crate::tools::run_graph_gates(&root, true, false, None);
+        assert!(
+            at_root[0].is_skipped(),
+            "the container root has no src/, so a root-anchored circular run skips"
+        );
+
+        // The fix: fanning out to the discovered package targets detects the cycle.
+        let detected = root
+            .package_targets()
+            .iter()
+            .flat_map(|t| crate::tools::run_graph_gates(t, true, false, None))
+            .any(|r| r.is_failure());
+        assert!(
+            detected,
+            "circular must detect the cycle inside packages/app/src"
+        );
+    }
+
+    // Dependency directories never count as packages even when they contain a
+    // package.json, so discovery does not fan a gate out into node_modules.
+    #[test]
+    fn discovery_skips_node_modules() {
+        let tmp = TempDir::new("nested-nodemodules");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        fs::write(tmp.join("package.json"), "{}").unwrap();
+        let dep = tmp.join("node_modules/some-dep");
+        fs::create_dir_all(&dep).unwrap();
+        fs::write(dep.join("package.json"), "{}").unwrap();
+        let pkg = tmp.join("packages/app");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(pkg.join("package.json"), "{}").unwrap();
+
+        let targets = ProjectInfo::detect(&tmp).package_targets();
+        assert!(
+            targets
+                .iter()
+                .all(|t| !t.root.starts_with(tmp.join("node_modules"))),
+            "node_modules packages must not be discovered as targets"
+        );
+        assert!(
+            targets.iter().any(|t| t.root == pkg),
+            "real packages are still discovered"
+        );
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -85,6 +85,24 @@ impl ToolResult {
             GateOutcome::Passed | GateOutcome::Skipped => "",
         }
     }
+
+    /// Prefix a package label onto the failure/warning output so per-package
+    /// gate runs in a monorepo container stay distinguishable: two packages
+    /// that each fail `circular` render the same `✗ circular` header, and their
+    /// bodies are path-relative to each package's own `src/`, so without the
+    /// label they collide. Passing/Skipped results carry no output and are
+    /// returned unchanged. The label is added only at the fan-out site when the
+    /// target is a discovered package, so a self-contained root (the single
+    /// target equals the project root) is never labeled and its output is
+    /// byte-identical to a root-only run.
+    pub fn scoped(mut self, label: &str) -> Self {
+        self.outcome = match self.outcome {
+            GateOutcome::Failed(text) => GateOutcome::Failed(format!("[{label}]\n{text}")),
+            GateOutcome::Warned(text) => GateOutcome::Warned(format!("[{label}]\n{text}")),
+            other => other,
+        };
+        self
+    }
 }
 
 fn kill_process_group(pid: u32) {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -26,6 +26,12 @@ pub struct GateDefinition {
     pub args: &'static [&'static str],
     pub hint: &'static str,
     pub condition: fn(&ProjectInfo) -> bool,
+    /// Whether this gate fans out over the discovered package targets. A
+    /// tsconfig-anchored gate (tsgo, oxlint) must run inside the package that
+    /// owns the config, so in a monorepo container it runs once per member
+    /// (#102). A workspace-aware or config-driven gate (knip, depcruise) reads
+    /// the whole tree from the root in one pass, so it stays root-anchored.
+    pub per_package: bool,
 }
 
 pub struct InstallInfo {
@@ -67,6 +73,9 @@ pub const GATES: &[GateDefinition] = &[
         args: &[],
         hint: "Remove unused exports and dependencies.",
         condition: |p| p.has_package_json,
+        // knip reads workspaces from the root manifest and resolves every member
+        // in a single pass, so a per-package fan-out would double-report.
+        per_package: false,
     },
     GateDefinition {
         name: "tsgo",
@@ -74,6 +83,9 @@ pub const GATES: &[GateDefinition] = &[
         args: &[],
         hint: "Fix type errors.",
         condition: |p| p.has_tsconfig,
+        // tsgo type-checks the tsconfig in its working directory, so in a
+        // monorepo container it must run inside each package that owns one.
+        per_package: true,
     },
     // Type-aware lint (backend: tsgolint). `--max-warnings 0` promotes oxlint's
     // default-severity findings (type-aware rules emit as warnings) to a nonzero
@@ -86,6 +98,9 @@ pub const GATES: &[GateDefinition] = &[
         args: &["--type-aware", "--max-warnings", "0"],
         hint: "Fix type-aware lint violations (e.g. floating promises).",
         condition: |p| p.has_tsconfig && tsgolint_available(&p.root),
+        // Type-aware lint resolves the tsconfig and tsgolint backend in its
+        // working directory, so like tsgo it fans out per owning package.
+        per_package: true,
     },
     // dependency-cruiser auto-detects .dependency-cruiser.{js,cjs,mjs,json} since v13,
     // so --config is omitted; the condition gates on the same four formats it detects.
@@ -100,6 +115,9 @@ pub const GATES: &[GateDefinition] = &[
                 .iter()
                 .any(|ext| p.root.join(format!(".dependency-cruiser.{ext}")).exists())
         },
+        // dependency-cruiser is config-driven: its `.dependency-cruiser.*` config
+        // sets the scope, so it runs from the root where the config lives.
+        per_package: false,
     },
 ];
 
@@ -1211,6 +1229,7 @@ mod tests {
             args: &[],
             hint: "",
             condition: |_| true,
+            per_package: false,
         };
         let project = test_project(true, true);
         let result = run_gate(&gate, &project);


### PR DESCRIPTION
## 問題 (#102)
`.git` が外側コンテナにあり tsconfig.json/src が `packages/foo` にある monorepo で、`ProjectInfo::detect` が root を `.git` 境界に解決し config 存在をその root のみで判定するため、config を所有するパッケージを silently skip していた。fail-open ではなく false pass。

## 修正
either/or 判別子で対応。git root が解析対象コード (tsconfig か root `src/`) を直接所有するなら root のみ対象 (非 monorepo は byte-identical で無変更)、コンテナなら member へ fan-out。両方は走らせない。

対象は in-directory config に anchor される 4 ゲートのみ:
- tsgo, oxlint (`per_package: true`)
- circular, coupling (member ごとの src/ グラフ)

knip / depcruise / litmus は root-anchored のまま。

member 結果は root 相対パッケージ名でラベル付け (`ToolResult::scoped`) し path collision を防止。ラベルは target が root と異なる時のみ付与し self-contained 出力を byte-identical に保つ。

## テスト
- #102 Red 再現テスト (root-anchored skip / fan-out で cycle 検出)
- 2 member ラベリングテスト (`[packages/a]`/`[packages/b]` 独立ブロック)
- self-contained 無ラベル不変条件
- 265 passed / 0 failed、clippy・fmt clean

## 既知制約
discovery は manifest 非読みの downward read_dir (深さ4 + 除外名)。深くネストした member は取りこぼす。解析対象コードを所有しつつ packages もネストする root は root のみ実行。ADR-0007 に記録。

Closes #102

https://claude.ai/code/session_016sgb3rgG1482AxusuSTyuw