### PR TITLE
docs: ADR-0005/0006 に合わせてコードコメントを整合 (#103)

### DIFF
--- a/src/hook_exit.rs
+++ b/src/hook_exit.rs
@@ -22,16 +22,21 @@
 //! here, as `join_or_skip` already maps them to `skipped`. Per Group 3 a non-2
 //! exit stays non-blocking, so 70 surfaces the fault without breaking fail-open.
 //! On the hook path `Blocking` is converted to stdout JSON + exit 0 by the
-//! caller. `Advisory` (1) is reserved: every gate today is blocking. `EX_IOERR`
-//! (74) on the `gates show` path is an ADR-0060 I/O code orthogonal to this enum
-//! and lives as a separate constant.
+//! caller. `Advisory` (1) is reserved: the advisory tier does exist — three
+//! gates mint `GateOutcome::Warned` (litmus, jscpd, the TS2307 downgrade) — but
+//! ADR-0005 deliberately routes those findings to stderr at exit 0, so no
+//! advisory *outcome* ever reaches this advisory *exit code*. `EX_IOERR` (74) on
+//! the `gates show` path is an ADR-0060 I/O code orthogonal to this enum and
+//! lives as a separate constant.
 
 // `Pass`, `Advisory`, and `Blocking` are reserved at the type level per issue
 // #18: the hook wrapper keeps exit 0 for the decision surface, so `Pass` (0) and
-// `Blocking` (2) never reach a live exit and `Advisory` (1) has no producer yet.
-// `InputError` and `Internal` are live (see the module doc). The full Group 3
-// mapping is kept so a future hook-spec change can switch the surface without
-// redefining the type.
+// `Blocking` (2) never reach a live exit. `Advisory` (1) likewise never reaches a
+// live exit, but for a different reason: the advisory tier *has* producers
+// (`GateOutcome::Warned`), yet ADR-0005 routes them to stderr at exit 0 rather
+// than to this exit code. `InputError` and `Internal` are live (see the module
+// doc). The full Group 3 mapping is kept so a future hook-spec change can switch
+// the surface without redefining the type.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookExitCode {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -149,10 +149,13 @@ impl EnvOverrides {
 
     /// Reads the command overrides through an injected getter so tests can
     /// exercise the env-name contract without mutating process-global state
-    /// (`env::set_var` is `unsafe`, which this crate forbids). Override names
-    /// carry the `GATES_` prefix to avoid colliding with unrelated CI/project
-    /// vars (a bare `TEST_CMD=jest` would otherwise silently hijack the gate);
-    /// no bare fallback is read, so the collision cannot reappear (#95).
+    /// (`env::set_var` is `unsafe`, which this crate forbids). Gate *command*
+    /// overrides carry the `GATES_` prefix to avoid colliding with unrelated
+    /// CI/project vars (a bare `TEST_CMD=jest` would otherwise silently hijack
+    /// the gate); no bare fallback is read, so the collision cannot reappear
+    /// (#95). The prefix rule is scoped to these command overrides only —
+    /// standard vars (`HOME`, `XDG_DATA_HOME`, `NO_COLOR`) are still read bare by
+    /// design, since they carry no gate-specific collision risk.
     fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Self {
         let cmd = |key: &str| get(key).filter(|s| !s.is_empty());
         Self {

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -5,7 +5,9 @@ const MAX_TRAVERSAL_DEPTH: usize = 20;
 
 /// Stops at the `.git` boundary (after visiting that directory), at `$HOME`
 /// (which is inspected but whose ancestors are not), or at the depth limit.
-/// The `$HOME` fence mirrors formatter's `bounded_ancestors` so the two
+/// The `$HOME` fence is load-bearing, not cosmetic: the walk must never escape
+/// `$HOME` into shared parents (`/Users`, `/home`, `/`), so removing the fence is
+/// a containment regression. It also mirrors formatter's `bounded_ancestors` so the two
 /// resolvers' ancestor walks stay aligned (independent copies, no drift). The
 /// third sibling, guardrails, deliberately keeps a different model
 /// (`canonicalize` + `project_root` boundary, no fences) to preserve its


### PR DESCRIPTION
## 概要

ADR-0005 (advisory tier) / ADR-0006 (sister-hook mirror) の決定に合わせ、関連コメント 3 箇所を整合させる。挙動変更・テスト変更なし (TIDYINGS 範囲)。Closes #103。

## 変更

### 1. hook_exit.rs — stale コメント訂正
「`Advisory` (1) is reserved: every gate today is blocking」「`Advisory` (1) has no producer yet」は **偽**。`GateOutcome::Warned` には 3 producer (litmus / jscpd / TS2307 downgrade) が存在する。以下 2 つを区別するよう訂正:
- advisory **tier** は存在する (producer あり) — 訂正
- advisory **outcome は exit code に到達しない** (ADR-0005 が stderr→exit 0 に分離) — 維持

### 2. traverse.rs — `$HOME` fence の forward rule 追記
`walk_ancestors` の `$HOME` fence が「formatter alignment」だけでなく containment invariant として load-bearing である旨を明示。traversal は `$HOME` を超えてはならず、fence 除去は regression。

### 3. tools.rs — `GATES_` override スコープ精緻化
`GATES_` prefix 必須は gate **command override** に限定。`HOME` / `XDG_DATA_HOME` / `NO_COLOR` は意図的に bare 参照、と明記し過剰表現を回避。

## 確認

- `cargo build` / `cargo test` 共に green (265 passed)
- diff はコメントのみ (22 insertions, 12 deletions)

## 出典
- ADR-0005 (docs/decisions/0005-*.md) / ADR-0006 (docs/decisions/0006-*.md)
- docs/audit/2026-06-30-094151-adr-gaps.md の downgrade / bug-fix follow-ups

https://claude.ai/code/session_016sgb3rgG1482AxusuSTyuw