### PR TITLE
fix: clone gate を nested-package monorepo の src 所有メンバーに fan-out (#105)

### DIFF
--- a/docs/decisions/0007-fan-package-scoped-gates-out-over-monorepo-members.md
+++ b/docs/decisions/0007-fan-package-scoped-gates-out-over-monorepo-members.md
@@ -28,10 +28,11 @@ decision-makers: [thkt]
 
 Chosen option: `ProjectInfo::package_targets` (project.rs:68-79) returns the directories the package-scoped gates run against, by an either/or discriminator. When the git root directly owns analyzable code (`has_tsconfig` or a root `src/`), the root is the sole target — today's behavior, so every non-monorepo repo is unchanged. Otherwise the root is a container and discovery descends (bounded `MAX_PACKAGE_DEPTH = 4`, excluding dependency/build dirs) to the member directories that own a `package.json` or `tsconfig.json`, stopping descent once a package matches so a member's own fixtures are not promoted to separate targets (project.rs:90-116). The root and the members are never both run — union would double-report.
 
-Exactly four gates fan out, selected by where their scope is anchored:
+Exactly five gates fan out, selected by where their scope is anchored:
 
 - tsgo, oxlint — anchored on the in-directory `tsconfig.json`, marked `per_package: true` (tools.rs:88, 103). They run once per member that owns a tsconfig; a member without one self-skips via the existing `condition`.
 - circular, coupling — read each member's own `src/` dependency graph, fanned out in `run_with_overrides` (main.rs:207-231) building one graph per member.
+- clone — reads each member's own `src/` tree for structural clones, fanned out in `run_with_overrides` (main.rs:236-263) analyzing one tree per member (#105, the same root-only skip as #102 but missed by that fan-out).
 
 Three gates stay root-anchored: knip resolves workspaces from the root manifest in one pass, depcruise is config-driven, and litmus already uses a recursive `**/*.test.ts` glob from the root (tools.rs:390) that covers every member, so per-package would double-report.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,7 +234,11 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
     }
 
     if config.is_enabled("clone") {
-        let p = project.clone();
+        // clone reads each package's own `src/` tree, so like circular/coupling
+        // it fans out over the discovered targets and labels each result with
+        // its owning package; a self-contained root yields one unlabeled result.
+        let clone_targets = targets.clone();
+        let root = project.root.clone();
         let min_nodes = config.clone.min_nodes.unwrap_or(clone::DEFAULT_MIN_NODES);
         let min_lines = config.clone.min_lines.unwrap_or(clone::DEFAULT_MIN_LINES);
         let block_threshold = config
@@ -244,7 +248,16 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
         tasks.push((
             vec!["clone"],
             thread::spawn(move || {
-                vec![tools::run_clone(&p, min_nodes, min_lines, block_threshold)]
+                clone_targets
+                    .iter()
+                    .map(|t| {
+                        scope_result(
+                            tools::run_clone(t, min_nodes, min_lines, block_threshold),
+                            &t.root,
+                            &root,
+                        )
+                    })
+                    .collect()
             }),
         ));
     }
@@ -1514,6 +1527,74 @@ mod tests {
             plain.contains("circular"),
             "the circular gate must fire: {plain}"
         );
+        assert!(
+            !plain.contains('['),
+            "a self-contained root must not label its output: {plain}"
+        );
+    }
+
+    // A duplicated function spanning 6 lines / >20 AST nodes, copied verbatim;
+    // two copies form one clone group. Mirrors tools::tests::CLONE_BODY.
+    const CLONE_BODY: &str = "export function compute(a: number, b: number) {\n  const x = a + b;\n  const y = x * 2;\n  const z = y - 1;\n  const w = z / 3;\n  return w + x;\n}\n";
+
+    // #105 (#102 same-shape): clone is a per-package src-axis gate, but its
+    // dispatch ran against the root alone. In a nested-package monorepo (root
+    // owns the workspace manifest, `src/` lives in `packages/app`) the root has
+    // no `src/`, so `run_clone` skipped instead of analyzing the member that
+    // owns the duplication. The fan-out must run clone inside `packages/app` and
+    // label the failure with that package.
+    #[test]
+    fn clone_fans_out_into_nested_package_and_labels_scope() {
+        let tmp = setup_project(
+            r#"{"gates":{"clone":true},"clone":{"blockThreshold":1}}"#,
+            &["package.json"],
+        );
+        let src = tmp.join("packages/app/src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(tmp.join("packages/app/package.json"), "{}").unwrap();
+        fs::write(src.join("a.ts"), CLONE_BODY).unwrap();
+        fs::write(src.join("b.ts"), CLONE_BODY).unwrap();
+
+        let block = run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                audit_dir: Some(tmp.join("audit")),
+                ..Default::default()
+            },
+        )
+        .expect("the nested clone must block");
+        let plain = color::strip_ansi(&block);
+        assert!(plain.contains("clone"), "the clone gate must fire: {plain}");
+        assert!(
+            plain.contains("[packages/app]"),
+            "the failure must be labeled with the owning package: {plain}"
+        );
+    }
+
+    // The self-contained-root invariant for clone: a project owning its own
+    // `src/` runs the gate at the root and emits no package label, so single-
+    // package output stays byte-identical to the pre-fan-out behavior.
+    #[test]
+    fn clone_self_contained_root_failure_carries_no_scope_label() {
+        let tmp = setup_project(
+            r#"{"gates":{"clone":true},"clone":{"blockThreshold":1}}"#,
+            &["package.json"],
+        );
+        let src = tmp.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("a.ts"), CLONE_BODY).unwrap();
+        fs::write(src.join("b.ts"), CLONE_BODY).unwrap();
+
+        let block = run_with_overrides(
+            &tmp,
+            &tools::EnvOverrides {
+                audit_dir: Some(tmp.join("audit")),
+                ..Default::default()
+            },
+        )
+        .expect("the root clone must block");
+        let plain = color::strip_ansi(&block);
+        assert!(plain.contains("clone"), "the clone gate must fire: {plain}");
         assert!(
             !plain.contains('['),
             "a self-contained root must not label its output: {plain}"


### PR DESCRIPTION
## 問題
`run_clone` (src/tools.rs:573) は `project.root.join("src")` のみ参照し、`!has_package_json || !src_dir.is_dir()` で skip 判定する。`.git` が外側コンテナにあり `src/` が `packages/foo` にある nested-package monorepo では root に `src/` が無く `src_dir.is_dir()` が false になり skip する。member の `src/` を見れば解析できたのに root だけ見て skip する false pass。#104 (#102) の root/`src` バグと同型だが、clone は当時の fan-out 4 ゲートに含まれていなかった。

## 修正
`run_with_overrides` の clone ブロックを circular/coupling と同じく `package_targets()` で fan-out し、各結果を `scope_result` でラベル付けする。`run_clone` は既に `&ProjectInfo` を受けるためシグネチャ変更は不要。

ADR-0007 の "Exactly four gates fan out" 列挙が本変更で事実誤りになるため five に更新し clone を追記 (リポの ADR-コード整合方針に沿う)。

## テスト
- `clone_fans_out_into_nested_package_and_labels_scope`: root に `package.json`・`src/` 無し、`packages/app/src` に構造的重複 → clone 発火 + `[packages/app]` ラベル
- `clone_self_contained_root_failure_carries_no_scope_label`: 自己完結 root はラベル無し (ゼロリグレッション不変条件)
- 全 267 pass

## スコープ外確認
`run_jscpd` は `project.root` を再帰スキャンするため同型 skip バグは無し。

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sgb3rgG1482AxusuSTyuw