### PR TITLE
fix: litmus を root-manifest 無し monorepo の member test に適用 (#106)

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -404,10 +404,15 @@ fn analyze_files_on_deep_stack(files: &[PathBuf]) -> litmus::AnalysisResult {
 }
 
 pub fn run_litmus(project: &ProjectInfo) -> Vec<ToolResult> {
-    if !project.has_package_json {
-        return vec![ToolResult::skipped("litmus")];
-    }
-
+    // Guard on whether there is anything to analyze — non-empty `find_test_files`
+    // — not on a root `package.json`. litmus runs once at the root and
+    // `find_test_files` recurses into members (excluding node_modules), so a
+    // single root run covers a monorepo's packages; that recursion is why litmus
+    // stays off the per-package fan-out (#104). A root-only `has_package_json`
+    // guard diverged from that real precondition: a root-manifest-less layout
+    // (members own the manifests) skipped every test despite owning real ones
+    // (#106). The test-file walk is the actual precondition, so let its emptiness
+    // be the skip condition.
     let files = litmus::find_test_files(&project.root);
     if files.is_empty() {
         return vec![ToolResult::skipped("litmus")];
@@ -1551,10 +1556,52 @@ mod tests {
     }
 
     #[test]
-    fn litmus_skips_without_package_json() {
-        let project = test_project(false, false);
+    fn litmus_skips_when_tree_has_no_tests_even_without_a_manifest() {
+        // No test files anywhere (and no manifest): litmus has nothing to analyze
+        // and skips. The skip is driven by the empty test-file walk, not by the
+        // absent root manifest (#106) — a tree with member tests would run.
+        let tmp = TempDir::new("litmus-no-manifest");
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: false,
+            has_tsconfig: false,
+        };
         let result = run_litmus(&project);
         assert!(result.iter().any(ToolResult::is_skipped));
+    }
+
+    // Bug reproduction (#106): a root-manifest-less monorepo — no root
+    // package.json, the manifests live in members — owns real test files inside a
+    // package. litmus runs once at the root and `find_test_files` recurses into
+    // the member, so the tautological test must surface. Before the fix the
+    // root-only `has_package_json` guard skipped the whole run, a false pass.
+    #[test]
+    fn litmus_analyzes_member_tests_in_root_manifest_less_monorepo() {
+        let tmp = TempDir::new("litmus-rootless");
+        let pkg = tmp.join("packages/app");
+        fs::create_dir_all(pkg.join("src")).unwrap();
+        fs::write(pkg.join("package.json"), "{}").unwrap();
+        fs::write(
+            pkg.join("src/example.test.ts"),
+            r"
+import { test, expect } from 'vitest';
+test('works', () => {
+    expect(true).toBe(true);
+});
+",
+        )
+        .unwrap();
+        // The root owns no package.json; the member holds the manifest and tests.
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: false,
+            has_tsconfig: false,
+        };
+        let result = run_litmus(&project);
+        assert!(
+            result.iter().any(ToolResult::is_failure),
+            "tautological member test must block despite the root owning no manifest: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景 (#106)

`run_litmus` の `if !project.has_package_json { skipped }` ガードは root の `package.json` のみを判定していた。root に manifest が無く member (`packages/app/package.json`) が manifest を持つ monorepo では、member に実テストが存在しても litmus が全 skip し、テスト品質を一切検査しない false pass が発生していた。

## 修正

litmus は #104 の判断どおり**単一 root 実行**で、`find_test_files` が `node_modules`/`dist` 等を除外しつつ member へ再帰するため、root 実行だけで member を網羅する。root-only の `has_package_json` ガードはこの実 precondition から乖離していた。

ガードを撤去し、`find_test_files` の空判定（解析対象の有無）を skip 条件に一本化。これにより root の manifest 有無に依らず、解析対象のテストがあれば検査する。

- 候補1 (`package_targets().any(has_package_json)`) ではなく候補2 を採用。`find_test_files` 非空が litmus の実 precondition であり、`has_package_json` はそこから乖離するプロキシだったため根本原因修正となる (Occam: -guard 1個)
- per-package fan-out には**しない**: `find_test_files` の root 再帰が member を網羅済みで、fan-out は二重計上になる (#104 の方針維持)

## テスト

| manifest | tests | 期待 | テスト |
|---|---|---|---|
| true | true | run | `litmus_passes_with_good_tests` / `litmus_detects_tautological_test` |
| true | false | skip | `litmus_skips_when_no_test_files` |
| false | true | **run** | repro `litmus_analyzes_member_tests_in_root_manifest_less_monorepo` (新規) |
| false | false | skip | `litmus_skips_when_tree_has_no_tests_even_without_a_manifest` (旧 `litmus_skips_without_package_json` をリネーム) |

- repro test は旧ガードで Skipped → RED を確認後に修正で GREEN (member の tautological test を block)
- 全 268 テスト pass、変更ファイル (tools.rs) は clippy clean

https://claude.ai/code/session_016sgb3rgG1482AxusuSTyuw