### PR TITLE
test: project.rs テストの絶対パス呼び出しを use import に置換 (#111)

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -119,6 +119,7 @@ fn is_package_dir(dir: &Path) -> bool {
 mod tests {
     use super::*;
     use crate::test_utils::TempDir;
+    use crate::tools::run_graph_gates;
     use std::fs;
 
     #[test]
@@ -265,7 +266,7 @@ mod tests {
         let root = ProjectInfo::detect(&tmp);
         // The git root owns no `src/`, so a root-anchored run skips the gate —
         // documenting the pre-fix behavior the bug report describes.
-        let at_root = crate::tools::run_graph_gates(&root, true, false, None);
+        let at_root = run_graph_gates(&root, true, false, None);
         assert!(
             at_root[0].is_skipped(),
             "the container root has no src/, so a root-anchored circular run skips"
@@ -275,7 +276,7 @@ mod tests {
         let detected = root
             .package_targets()
             .iter()
-            .flat_map(|t| crate::tools::run_graph_gates(t, true, false, None))
+            .flat_map(|t| run_graph_gates(t, true, false, None))
             .any(|r| r.is_failure());
         assert!(
             detected,


### PR DESCRIPTION
## 概要

`cargo clippy --all-targets` が main で失敗する既存負債を解消する。`src/project.rs` の test モジュール (#102 で追加) が `crate::tools::run_graph_gates` を絶対パスで呼び、`Cargo.toml` の `[lints.clippy] absolute_paths = "deny"` に違反していた。

## 変更

- test モジュール先頭に `use crate::tools::run_graph_gates;` を追加
- `src/project.rs:268`, `:278` の絶対パス呼び出しを `run_graph_gates(...)` に短縮

プロダクションコードは無変更、挙動不変。

## 受け入れ条件

- [x] `cargo clippy --all-targets -- -D warnings` が 0 error
- [x] `cargo test` 全 pass (268 passed / 0 failed)

Closes #111

https://claude.ai/code/session_016sgb3rgG1482AxusuSTyuw