### PR TITLE
fix: 埋め込み/外部ゲートの走査層から .claude/ を除外 (#114)

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -3,9 +3,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Directory names package discovery never descends into: dependencies, VCS,
-/// build output, and coverage/next caches cannot own a first-party package
-/// target. Extends the list `depgraph`/`snapshot` apply to their own downward
-/// walks with the cache dirs that commonly hold copied `package.json` fixtures.
+/// build output, coverage/next caches, and Claude Code tooling cannot own a
+/// first-party package target. Extends the list `depgraph`/`snapshot` apply to
+/// their own downward walks with the cache dirs that commonly hold copied
+/// `package.json` fixtures and `.claude`, whose `plugins/<plugin>` members carry
+/// their own manifests but are third-party tooling, not code to gate.
 const EXCLUDED_DIRS: &[&str] = &[
     "node_modules",
     ".git",
@@ -14,6 +16,7 @@ const EXCLUDED_DIRS: &[&str] = &[
     "target",
     "coverage",
     ".next",
+    ".claude",
 ];
 
 /// How many directory levels below the git root package discovery descends. A
@@ -304,6 +307,34 @@ mod tests {
                 .iter()
                 .all(|t| !t.root.starts_with(tmp.join("node_modules"))),
             "node_modules packages must not be discovered as targets"
+        );
+        assert!(
+            targets.iter().any(|t| t.root == pkg),
+            "real packages are still discovered"
+        );
+    }
+
+    // Claude Code tooling directories (`.claude/plugins/<plugin>` carrying their
+    // own `package.json`) are third-party config, not first-party packages, so
+    // discovery must not fan the gates out into them.
+    #[test]
+    fn discovery_skips_claude_dir() {
+        let tmp = TempDir::new("nested-claude");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        fs::write(tmp.join("package.json"), "{}").unwrap();
+        let plugin = tmp.join(".claude/plugins/some-plugin");
+        fs::create_dir_all(&plugin).unwrap();
+        fs::write(plugin.join("package.json"), "{}").unwrap();
+        let pkg = tmp.join("packages/app");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(pkg.join("package.json"), "{}").unwrap();
+
+        let targets = ProjectInfo::detect(&tmp).package_targets();
+        assert!(
+            targets
+                .iter()
+                .all(|t| !t.root.starts_with(tmp.join(".claude"))),
+            ".claude packages must not be discovered as targets"
         );
         assert!(
             targets.iter().any(|t| t.root == pkg),

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -18,9 +18,12 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-/// Directories whose contents never belong to the gated fileset. Mirrors
-/// `depgraph::EXCLUDED_DIRS` plus `coverage`/`.next` (test/build artifacts that
-/// gates never lints).
+/// Directories whose contents never belong to the gated fileset: dependencies,
+/// VCS, build/test artifacts (`dist`/`build`/`target`/`coverage`/`.next`), and
+/// `.claude` (Claude Code tooling, whose `plugins/<plugin>` sources are
+/// third-party and are also excluded from package discovery at `project.rs`).
+/// Kept in sync with `project.rs::EXCLUDED_DIRS`; `depgraph`'s list is narrower
+/// because it only walks `src/` downward and never reaches these siblings.
 const EXCLUDED_DIRS: &[&str] = &[
     "node_modules",
     ".git",
@@ -29,6 +32,7 @@ const EXCLUDED_DIRS: &[&str] = &[
     "target",
     "coverage",
     ".next",
+    ".claude",
 ];
 
 /// Source extensions gates consumes (tsc/eslint/embedded gates).
@@ -275,6 +279,20 @@ mod tests {
         let before = compute_digest(&root);
         fs::create_dir_all(root.join("dist")).unwrap();
         fs::write(root.join("dist/bundle.ts"), "ignored").unwrap();
+        let after = compute_digest(&root);
+        assert_eq!(before, after);
+    }
+
+    // Changes under `.claude/` (Claude Code tooling, e.g. a plugin's source)
+    // do not change the digest, so editing a plugin file never triggers a full
+    // gate re-run for first-party code that did not change.
+    #[test]
+    fn digest_unchanged_on_claude_dir_edit() {
+        let root = TempDir::new("snap-claude");
+        fs::write(root.join("a.ts"), "x").unwrap();
+        let before = compute_digest(&root);
+        fs::create_dir_all(root.join(".claude/plugins/p/src")).unwrap();
+        fs::write(root.join(".claude/plugins/p/src/index.ts"), "ignored").unwrap();
         let after = compute_digest(&root);
         assert_eq!(before, after);
     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -90,7 +90,7 @@ fn collect_targets(dir: &Path, root: &Path, out: &mut Vec<(String, PathBuf)>) {
 ///
 /// Walks `root` for `.ts/.tsx/.cts/.mts/.js/.jsx/.cjs/.mjs` plus every
 /// `package.json` / `tsconfig*.json` (recursive, excluding
-/// `node_modules/.git/dist/build/target/coverage/.next`), feeding
+/// `node_modules/.git/dist/build/target/coverage/.next/.claude`), feeding
 /// (relative path, size, ctime secs, ctime nsecs) of each into a
 /// `DefaultHasher`. ctime is used over content bytes because the kernel bumps it
 /// on any inode write and userspace cannot backdate it (`utimes` touches only

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -99,13 +99,15 @@ pub const GATES: &[GateDefinition] = &[
         // descends hidden sibling dirs, so `.claude/plugins/<plugin>` sources
         // would be linted in a self-contained repo (cwd == root). `.gitignore`
         // suppresses them only when the repo ignores `.claude`, so exclude them
-        // unconditionally, matching the discovery/snapshot/jscpd exclusions.
+        // unconditionally. The `**/` prefix matches `.claude` at any depth, giving
+        // the same coverage as the jscpd (`**/.claude/**`) and Rust-walker
+        // (basename match) exclusions rather than only a cwd-level `.claude`.
         args: &[
             "--type-aware",
             "--max-warnings",
             "0",
             "--ignore-pattern",
-            ".claude/**",
+            "**/.claude/**",
         ],
         hint: "Fix type-aware lint violations (e.g. floating promises).",
         condition: |p| p.has_tsconfig && tsgolint_available(&p.root),
@@ -1400,8 +1402,8 @@ mod tests {
     fn oxlint_definition_uses_type_aware_without_type_check() {
         // Locks the exit-code contract: --max-warnings 0 makes warnings block, and
         // --type-check is omitted so type errors are not double-reported with tsgo.
-        // --ignore-pattern .claude/** keeps third-party plugin sources out of the
-        // cwd-anchored file walk in a self-contained repo.
+        // --ignore-pattern **/.claude/** keeps third-party plugin sources out of
+        // the file walk at any depth in a self-contained repo.
         let gate = gate_by_name("oxlint");
         assert_eq!(gate.command, "oxlint");
         assert_eq!(
@@ -1411,7 +1413,7 @@ mod tests {
                 "--max-warnings",
                 "0",
                 "--ignore-pattern",
-                ".claude/**"
+                "**/.claude/**"
             ]
         );
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -95,7 +95,18 @@ pub const GATES: &[GateDefinition] = &[
     GateDefinition {
         name: "oxlint",
         command: "oxlint",
-        args: &["--type-aware", "--max-warnings", "0"],
+        // No path arg: oxlint discovers files from its cwd. Its default walk
+        // descends hidden sibling dirs, so `.claude/plugins/<plugin>` sources
+        // would be linted in a self-contained repo (cwd == root). `.gitignore`
+        // suppresses them only when the repo ignores `.claude`, so exclude them
+        // unconditionally, matching the discovery/snapshot/jscpd exclusions.
+        args: &[
+            "--type-aware",
+            "--max-warnings",
+            "0",
+            "--ignore-pattern",
+            ".claude/**",
+        ],
         hint: "Fix type-aware lint violations (e.g. floating promises).",
         condition: |p| p.has_tsconfig && tsgolint_available(&p.root),
         // Type-aware lint resolves the tsconfig and tsgolint backend in its
@@ -646,9 +657,13 @@ pub const DEFAULT_JSCPD_THRESHOLD: f64 = 10.0;
 /// would otherwise blow the gate's timeout). jscpd's own docs use this glob.
 /// `.git` is not covered by gitignore (it is the git dir itself); its sample
 /// hooks are near-identical and would surface as clone groups, so exclude it.
+/// `.claude` holds Claude Code tooling (plugin sources) that is third-party and
+/// not first-party code to gate; it is excluded here for repos that do not
+/// gitignore it, mirroring the package-discovery/snapshot exclusions.
 pub const DEFAULT_JSCPD_IGNORE: &[&str] = &[
     "**/node_modules/**",
     "**/.git/**",
+    "**/.claude/**",
     "**/*.test.*",
     "**/*.spec.*",
     "**/generated/**",
@@ -933,6 +948,16 @@ mod tests {
         assert_eq!(overrides.type_cmd, None);
         assert_eq!(overrides.unit_cmd, None);
         assert_eq!(overrides.test_cmd, None);
+    }
+
+    #[test]
+    fn default_jscpd_ignore_excludes_claude_dir() {
+        // `.claude` plugin sources are third-party tooling; the default ignore
+        // must keep them out of clone detection so they never surface as groups.
+        assert!(
+            DEFAULT_JSCPD_IGNORE.contains(&"**/.claude/**"),
+            "DEFAULT_JSCPD_IGNORE must exclude .claude by default"
+        );
     }
 
     #[test]
@@ -1375,9 +1400,20 @@ mod tests {
     fn oxlint_definition_uses_type_aware_without_type_check() {
         // Locks the exit-code contract: --max-warnings 0 makes warnings block, and
         // --type-check is omitted so type errors are not double-reported with tsgo.
+        // --ignore-pattern .claude/** keeps third-party plugin sources out of the
+        // cwd-anchored file walk in a self-contained repo.
         let gate = gate_by_name("oxlint");
         assert_eq!(gate.command, "oxlint");
-        assert_eq!(gate.args, &["--type-aware", "--max-warnings", "0"]);
+        assert_eq!(
+            gate.args,
+            &[
+                "--type-aware",
+                "--max-warnings",
+                "0",
+                "--ignore-pattern",
+                ".claude/**"
+            ]
+        );
     }
 
     fn run_circular(project: &ProjectInfo) -> ToolResult {


### PR DESCRIPTION
## 背景

Claude Code の plugin フォルダ (`.claude/plugins/<plugin>/...`) が gates の各ゲートに走査され、サードパーティ由来のコードが clone / circular / coupling / jscpd / oxlint で false positive を出していた。#114 の提案 (ゲート個別の src サブフォルダ除外設定) ではなく、走査層で `.claude/` を除外する形で根本対処する。

## 変更

**メンバ探索・digest・外部ゲートの除外を横断追加:**
- `src/project.rs`: メンバパッケージ探索の `EXCLUDED_DIRS` に `.claude` を追加
- `src/snapshot.rs`: digest 走査の `EXCLUDED_DIRS` に `.claude` を追加
- `src/tools.rs`: jscpd の `DEFAULT_JSCPD_IGNORE` に `**/.claude/**`、oxlint に `--ignore-pattern **/.claude/**`

**depgraph.rs は変更なし**: `src/` 配下のみを下向き走査し `.claude` 兄弟に到達しないため。

## audit フォローアップ (このブランチで修正)

- F-17: oxlint の除外を `.claude/**` (cwd 直下のみ) → `**/.claude/**` に変更し jscpd/Rust walker と深度を揃えた
- F-22: `compute_digest` の doc コメントに欠落していた `.claude` を追記

## 別 issue へ切り出し (既存挙動)

- #117 RC-1: project.rs / snapshot.rs のバイト同一 const の DRY 統一
- #118 RC-2: jscpd.ignore の replace-not-merge
- #119 F-24: oxlint 非ゼロ exit の usage-error / lint-violation 区別

## テスト

`cargo test` 271 passed。追加テスト: `discovery_skips_claude_dir` / `digest_unchanged_on_claude_dir_edit` / `default_jscpd_ignore_excludes_claude_dir` と oxlint args のロックテスト更新。litmus の `.claude` 除外は依存元 pin の都合で #116 へ延期。

Closes #114

https://claude.ai/code/session_016owFKDuzkwYSWiW8hTmhsQ