### PR TITLE
fix: litmus の走査から .claude 配下のテストを除外 (#116)

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -416,17 +416,37 @@ fn analyze_files_on_deep_stack(files: &[PathBuf]) -> litmus::AnalysisResult {
     })
 }
 
+/// Drop every test file that lives under a `.claude` path component.
+///
+/// litmus' own `is_excluded` skips node_modules but not `.claude`, so
+/// `find_test_files` still collects third-party Claude Code plugin tests under
+/// `.claude/plugins/*`. Those are not this project's tests, so analyzing them
+/// surfaces false-positive findings on tooling the repo does not own. Match on a
+/// whole path component equal to `.claude` (mirroring litmus `is_excluded`'s
+/// full-path component match and the project.rs / snapshot.rs / jscpd / oxlint
+/// `.claude` convention) so `foo.claude` and the like are not swept up.
+fn without_claude_tests(files: Vec<PathBuf>) -> Vec<PathBuf> {
+    files
+        .into_iter()
+        .filter(|path| {
+            !path
+                .components()
+                .any(|c| c.as_os_str().to_str() == Some(".claude"))
+        })
+        .collect()
+}
+
 pub fn run_litmus(project: &ProjectInfo) -> Vec<ToolResult> {
-    // Guard on whether there is anything to analyze — non-empty `find_test_files`
-    // — not on a root `package.json`. litmus runs once at the root and
-    // `find_test_files` recurses into members (excluding node_modules), so a
-    // single root run covers a monorepo's packages; that recursion is why litmus
-    // stays off the per-package fan-out (#104). A root-only `has_package_json`
-    // guard diverged from that real precondition: a root-manifest-less layout
-    // (members own the manifests) skipped every test despite owning real ones
-    // (#106). The test-file walk is the actual precondition, so let its emptiness
-    // be the skip condition.
-    let files = litmus::find_test_files(&project.root);
+    // Guard on whether there is anything to analyze — the test-file walk after
+    // excluding `.claude` tooling — not on a root `package.json`. litmus runs
+    // once at the root and `find_test_files` recurses into members (excluding
+    // node_modules), so a single root run covers a monorepo's packages; that
+    // recursion is why litmus stays off the per-package fan-out (#104). A
+    // root-only `has_package_json` guard diverged from that real precondition: a
+    // root-manifest-less layout (members own the manifests) skipped every test
+    // despite owning real ones (#106). The `.claude`-excluded test-file walk is
+    // the actual precondition, so let its emptiness be the skip condition.
+    let files = without_claude_tests(litmus::find_test_files(&project.root));
     if files.is_empty() {
         return vec![ToolResult::skipped("litmus")];
     }
@@ -1795,6 +1815,113 @@ test("uppercases the provided first name", () => {
         assert!(
             result.iter().any(ToolResult::is_warning),
             "mixed run should keep the warning result: {result:?}"
+        );
+    }
+
+    #[test]
+    fn litmus_skips_when_only_tests_live_under_dot_claude_at_any_depth() {
+        // U-001 Red repro: the only test file lives below a package dir inside a
+        // `.claude` tree. Its body is tautological, so before the fix litmus
+        // analyzes it and blocks (a false positive on third-party tooling). After
+        // the fix the `.claude` file is dropped before the is_empty() guard, so
+        // nothing is analyzed and the run skips. The nested path proves the match
+        // is on a `.claude` component at any depth, not a root prefix.
+        let tmp = TempDir::new("litmus-claude-only");
+        let dir = tmp.join("packages/app/.claude/plugins/p");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("bad.test.ts"),
+            r"
+import { test, expect } from 'vitest';
+test('works', () => {
+    expect(true).toBe(true);
+});
+",
+        )
+        .unwrap();
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: false,
+            has_tsconfig: false,
+        };
+        let result = run_litmus(&project);
+        assert!(
+            result.iter().any(ToolResult::is_skipped),
+            "a .claude-only test tree must skip, not surface a finding: {result:?}"
+        );
+    }
+
+    #[test]
+    fn litmus_reports_real_test_but_not_dot_claude_sibling() {
+        // The filter removes only `.claude` paths; a real src/ test still blocks,
+        // proving the fix does not disable litmus wholesale (guards against an
+        // over-broad filter that drops every file).
+        let tmp = TempDir::new("litmus-claude-sibling");
+        let claude_dir = tmp.join(".claude/plugins/p/src");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(
+            claude_dir.join("bad.test.ts"),
+            r"
+import { test, expect } from 'vitest';
+test('works', () => {
+    expect(true).toBe(true);
+});
+",
+        )
+        .unwrap();
+        let src = tmp.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            src.join("bad.test.ts"),
+            r"
+import { test, expect } from 'vitest';
+test('works', () => {
+    expect(true).toBe(true);
+});
+",
+        )
+        .unwrap();
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: false,
+            has_tsconfig: false,
+        };
+        let result = run_litmus(&project);
+        assert!(
+            result.iter().any(ToolResult::is_failure),
+            "the real src/ test must still block after filtering .claude: {result:?}"
+        );
+    }
+
+    #[test]
+    fn litmus_excludes_dot_claude_as_exact_component_not_substring() {
+        // `foo.claude` contains the `.claude` substring but is not the exact
+        // component `.claude`. The filter matches whole path components only, so
+        // this file survives and its tautological body blocks. A substring impl
+        // (`contains(".claude")` or `contains("claude")`) would wrongly drop it
+        // and skip; this fixture catches both regressions.
+        let tmp = TempDir::new("litmus-claude-substring");
+        let dir = tmp.join("foo.claude");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("bad.test.ts"),
+            r"
+import { test, expect } from 'vitest';
+test('works', () => {
+    expect(true).toBe(true);
+});
+",
+        )
+        .unwrap();
+        let project = ProjectInfo {
+            root: tmp.to_path_buf(),
+            has_package_json: false,
+            has_tsconfig: false,
+        };
+        let result = run_litmus(&project);
+        assert!(
+            result.iter().any(ToolResult::is_failure),
+            "foo.claude is not the .claude component and must still block: {result:?}"
         );
     }
 


### PR DESCRIPTION
## 概要

litmus ゲートの `find_test_files` は `node_modules` を除外するが `.claude` を除外しないため、`.claude/plugins/*` 配下の Claude Code プラグイン由来テストまで解析対象に含め、リポジトリが所有しないツールに対して誤検知の findings を出していた (#116)。

`find_test_files` の結果を `analyze_files_on_deep_stack` へ渡す前に `without_claude_tests` (src/tools.rs 付近) でフィルタし、`.claude` をパスコンポーネントとして任意の深さで除外する。

## 記録済みの前提 (ユーザーの拒否権対象)

- **A vs B: B で進行** — gates 側 (`find_test_files` 出力から `.claude` アンカーのパスを `analyze_files_on_deep_stack` 前に除去、tools.rs:430 付近) を変更する。litmus の `EXCLUDED_DIRS` に `.claude` を追加する A ではない。
  - 基点: B は gates ローカルの変更で、外部公開・データ移行・破棄されるクロスリポジトリ作業がなく、両批評者とも B は安価に可逆でバグを修正すると認める。よって後で A に切り替えるコストは低い。A vs B の是非が対立する場合、可逆な選択肢が正しい自律的ベストゲス。 (irreversible: false)
- **B は `.claude` をルート接頭辞一致ではなく、任意の深さのパスコンポーネントとして除外する** — litmus `is_excluded` (lib.rs:145-147) と jscpd の `**/.claude/**` パターンを踏襲する。
  - 基点: Attack V4 — ルート接頭辞実装ではネストした `packages/foo/.claude/plugins/**` のテストが漏れる。任意深さのコンポーネント一致が #114 で確立された規約であり、ローカルで改訂可能なコード詳細。 (irreversible: false)

## backlog ステージが起票した Issue

- [refactor(test): tools.rs の vitest フィクスチャ重複を共有ヘルパへ抽出 (F-08)](https://github.com/thkt/gates/issues/121)

## 人間のトリアージ待ち backlog 候補

以下は backlog ステージが検出したが、build スコープ外 (自身の diff 内で解決すべき論点) または既存 issue と重複するため独立 issue 化を保留した候補。人間の判断待ち。

- **audit RC-1: .claude 除外リテラルが 5 箇所に散在 + cross-consistency test** — 既存 open #117 と RC-1 タグが同一で強く重複。#117 の body は 2 つのバイト同一 const 統一 + cross-list 整合テストを扱い、oxlint/jscpd の glob 文字列は『意味論が異なるため統一対象外』と明示的に検討・除外済み。本候補の広域統一は #117 で既に決着済みの決定を再燃させるため defer。人間が #117 に畳むか別起票するか判断。
- **challenge: A/B 判別基準 (leaky-abstraction / blast-radius) の反証** — #116 自身の A/B 設計選択への批評。build タスクのスコープ内で解決すべき設計論であり、out-of-scope の新規問題ではない。
- **challenge: litmus find_test_files を runtime excluded-dirs 引数で parameterize する第三案** — #116 自身の実装アプローチの代替案。build の設計判断に属し、独立 issue 化する out-of-scope 問題ではない。
- **challenge: jscpd 前例は native ignore で A 形、B を支持しない** — #116 の設計根拠に対するメタ批評。build 内で扱う論点で、out-of-scope の actionable な問題ではない。
- **challenge: Reuse Ordering 軸で A が B より妥当、選択は未確定** — #116 の意思決定の確度に対するメタ批評。build 内で解決する論点。
- **think V3: package.json フィクスチャの因果主張が誤り** — #116 自身の plan/フィクスチャ設計の欠陥。build が自分の diff で修正すべき事項で、backlog 材料ではない。
- **think V4: T-002 の good test 内容未指定 (spec gap)** — #116 自身のテスト計画の欠陥。build のテスト設計内で解決すべき。
- **think Occam/YAGNI: without_claude_tests の strip_prefix fail 分岐が dead code** — #116 が新規追加する関数自体の欠陥。build (code/polish) 内で修正すべきで out-of-scope ではない。
- **think V2: assumption #3 の文言誤り + tools.rs:420-428 の stale コメント** — #116 自身の推論と新規コードに関する指摘。build 内で修正すべき事項。
- **audit F-03/F-04: without_claude_tests フィルタの Vec::retain / OsStr 直接比較への tidy** — #116 が新規追加する without_claude_tests 関数のクリーンアップ。build の polish 段階で扱うべき自身の新規コードで out-of-scope ではない。
- **audit F-05: doc コメント node_modules の backtick 欠落 (clippy pedantic)** — #116 が新規追加する doc コメント (tools.rs:421) の指摘。build 内で修正すべき自身の変更。
- **audit F-13: pure filter を直接ユニットテストで検証** — #116 が新規追加する without_claude_tests のテスト構造。build のテスト設計内で解決すべき自身の新規コード。

## 未解決の critical/high findings

なし。

## plan ゲートのブロッカー

なし (plan ゲートは Ready)。

## code の Red 未確定アノマリー

なし。

## code の独立 verify 結果

tests=true / gates=true

Closes #116

https://claude.ai/code/session_01GsYZ1gnMxxfb5TSENGKTBi
