### PR TITLE
test: EXCLUDED_DIRS 統合に備えた project.rs/snapshot.rs のガードテストを追加 (refs #117)

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -121,7 +121,7 @@ fn is_package_dir(dir: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::TempDir;
+    use crate::test_utils::{GUARDED_EXCLUDED_DIR_NAMES, TempDir};
     use crate::tools::run_graph_gates;
     use std::fs;
 
@@ -312,6 +312,35 @@ mod tests {
             targets.iter().any(|t| t.root == pkg),
             "real packages are still discovered"
         );
+    }
+
+    // Guard for the EXCLUDED_DIRS consolidation (fixture rationale:
+    // test_utils::GUARDED_EXCLUDED_DIR_NAMES). The kept-pkg positive control
+    // also catches a degenerate "excludes everything" implementation.
+    #[test]
+    fn discovery_skips_all_hardcoded_excluded_names_but_keeps_control_pkg() {
+        let tmp = TempDir::new("discovery-all-excluded");
+        fs::create_dir_all(tmp.join(".git")).unwrap();
+        // No root package.json/tsconfig.json/src, so package_targets descends
+        // via discover_packages rather than the single-target short-circuit.
+
+        for &name in GUARDED_EXCLUDED_DIR_NAMES {
+            let dir = tmp.join(name);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join("package.json"), "{}").unwrap();
+        }
+        let kept = tmp.join("kept-pkg");
+        fs::create_dir_all(&kept).unwrap();
+        fs::write(kept.join("package.json"), "{}").unwrap();
+
+        let targets = ProjectInfo::detect(&tmp).package_targets();
+        assert_eq!(
+            targets.len(),
+            1,
+            "only kept-pkg should be discovered as a target, got {:?}",
+            targets.iter().map(|t| &t.root).collect::<Vec<_>>()
+        );
+        assert_eq!(targets[0].root, kept);
     }
 
     // Claude Code tooling directories (`.claude/plugins/<plugin>` carrying their

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -169,7 +169,7 @@ pub fn write(dir: &Path, root: &Path, digest: &str) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::TempDir;
+    use crate::test_utils::{GUARDED_EXCLUDED_DIR_NAMES, TempDir};
     use std::fs;
     use std::os::unix::fs::symlink;
     use std::process::Command;
@@ -397,6 +397,40 @@ mod tests {
         let root = TempDir::new("snap-t020-root");
         let missing = root.join("absent-snapshot-dir");
         assert_eq!(read_stored(&missing, &root), None);
+    }
+
+    // Guard for the EXCLUDED_DIRS consolidation (fixture rationale:
+    // test_utils::GUARDED_EXCLUDED_DIR_NAMES). The kept.ts positive control
+    // also catches a degenerate constant/empty digest.
+    #[test]
+    fn digest_ignores_all_hardcoded_excluded_dirs_but_tracks_control_file() {
+        let root = TempDir::new("snap-all-excluded");
+        let excluded_names = GUARDED_EXCLUDED_DIR_NAMES;
+        for &name in excluded_names {
+            let dir = root.join(name);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join(format!("{name}.ts")), "x").unwrap();
+        }
+        fs::create_dir_all(root.join("kept")).unwrap();
+        fs::write(root.join("kept/kept.ts"), "x").unwrap();
+
+        let before = compute_digest(&root);
+
+        for &name in excluded_names {
+            fs::write(root.join(name).join(format!("{name}.ts")), "edited").unwrap();
+        }
+        let after_excluded_edit = compute_digest(&root);
+        assert_eq!(
+            before, after_excluded_edit,
+            "edits confined to excluded dirs must not change the digest"
+        );
+
+        fs::write(root.join("kept/kept.ts"), "edited").unwrap();
+        let after_control_edit = compute_digest(&root);
+        assert_ne!(
+            before, after_control_edit,
+            "an edit to the control file outside excluded dirs must change the digest"
+        );
     }
 
     // T-022: a stat-failed file contributes a sentinel rather than being dropped

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -8,6 +8,21 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Fixture for the `project.rs`/`snapshot.rs` EXCLUDED_DIRS consolidation
+/// guard tests. A literal, deliberately not a reference to either production
+/// `EXCLUDED_DIRS` array, so deleting an entry from either array diverges
+/// this expectation from actual behavior and fails the guard test.
+pub const GUARDED_EXCLUDED_DIR_NAMES: &[&str] = &[
+    "node_modules",
+    ".git",
+    "dist",
+    "build",
+    "target",
+    "coverage",
+    ".next",
+    ".claude",
+];
+
 pub struct TempDir {
     path: PathBuf,
 }


### PR DESCRIPTION
## 概要

refs #117。`project.rs`/`snapshot.rs` のバイト同一 `EXCLUDED_DIRS` を単一の共有元へ統一する準備として、統一後も discovery/digest の外部可観測な挙動が維持されることを検証するガードテストを追加した。

TDD の Red 確認手順を踏んだ結果、今回のビルドでは本番コードの統合(const の一本化)は実施していない。理由は下記 (6) を参照。**この PR は #117 をクローズしない** (`refs #117` のみ)。統合本体は #117 の残作業として引き続き残る。

---

### (1) 記録された前提 (ユーザーの拒否権対象)

- No depgraph⊆project subset-assertion test is added in this task; cross-list test coverage is limited to the project.rs/snapshot.rs merge becoming tautological-by-construction (i.e., the 'cross-list integrity test' literal ask is satisfied by the merge itself, not by a separate depgraph-referencing test).
  - **basis**: Attack 1 (verified directly against depgraph.rs:9) proved the literal subset test is uncompilable without editing depgraph.rs, contradicting the premise's own 'depgraph.rs stays untouched' bound. Test-only, trivially reversible if the user wants that coverage added later.
- project.rs's doc comment is updated to say snapshot.rs no longer carries its own copy of the list.
  - **basis**: Comment-only edit bundled into the merge; freely revisable.
- The 'fixes RC-1 by construction' framing is scoped explicitly to the project.rs/snapshot.rs pair only, not the full .claude coordination surface.
  - **basis**: Attack 2 verified via `git show 8441ec4` that 3 production files changed (not 2) and PR #116 added a 4th layer (litmus, tools.rs:434); oxlint (tools.rs:110) and jscpd (tools.rs:688) patterns remain independent. Scoping the claim is a messaging choice, not a code change, cheaply revised.

### (2) バックログ段階で起票された Issue

- [robustness: .claude 除外知識が4層 (project/snapshot/depgraph/tools) に分散し整合性ガードがない](https://github.com/thkt/gates/issues/123)
- [refactor(test): project.rs/snapshot.rs の EXCLUDED_DIRS guard テストのセットアップ重複を共有ヘルパへ抽出](https://github.com/thkt/gates/issues/124)

### (3) 人間トリアージ待ちのバックログ候補

- **Re-fork risk: dropping `use crate::project::EXCLUDED_DIRS` in snapshot.rs could silently reintroduce the two-lists-drift class**
  - reason: Overlaps #117's own stated scope (#117 body already commits to adding a 'cross-list consistency test' — this is the assert_eq!/shared-const guard the audit's RC-1/F-006 findings recommend). Production consolidation itself hasn't landed yet in this build (only guard tests were added; TDD Red was unreachable so no prod change was made). Treat as part of #117's remaining work, not a separate backlog item — re-evaluate only if #117 ships without that guard.
- **depgraph⊆project subset-test caveat (walk-scope coincidence, not proven containment)**
  - reason: Not independently actionable — it's a caution about a hypothetical future test the candidate itself says is 'not in this task.' Folded as a caveat paragraph into the filed issue #123 (4-layer coordination) rather than filed standalone.
- **Hidden-cost: merging EXCLUDED_DIRS loses snapshot.rs's digest-fileset doc rationale**
  - reason: Applies to the production const merge, which hasn't been implemented yet in the working tree (verified via git diff — only test/fixture additions exist, no `pub(crate)` export or `use` in snapshot.rs). Premature to file until the merge actually happens; belongs to #117's own execution, not a new issue.
- **Test tautology: T-001/T-002 fixtures iterating the EXCLUDED_DIRS symbol under test**
  - reason: Verified moot by reading the actual diff: test_utils.rs's GUARDED_EXCLUDED_DIR_NAMES is a hardcoded literal array with a doc comment explicitly stating it deliberately does not reference either production EXCLUDED_DIRS array, precisely to preserve the drift-canary property this candidate worried about losing. No action needed.
- **RC-1 (no single source of truth for EXCLUDED_DIRS) and F-006 (no prod-vs-prod equality test)**
  - reason: These are not out-of-scope discoveries — they are the literal reason #117 exists (#117's own body: 'この2定数はバイト同一で...整合性を保証するテストがない'). Filing a duplicate issue for the root cause the current build task already targets would fragment tracking; leave them to #117.

### (4) 未解決の critical/high findings

None.

### (5) plan gate が Ready でない場合のブロッカー

None. (plan gate is Ready)

### (6) code 段階の Red-unconfirmed anomalies

- **U-001** (kind: `no-red`)

  Re-ran the full suite (cargo test: 276 passed, 0 failed) and confirmed both target tests currently pass: `project::tests::discovery_skips_all_hardcoded_excluded_names_but_keeps_control_pkg` and `snapshot::tests::digest_ignores_all_hardcoded_excluded_dirs_but_tracks_control_file`. Scrutinized both bodies (src/project.rs:324-357, src/snapshot.rs:408-445): they invoke the real production entry points (`ProjectInfo::detect(...).package_targets()`, `compute_digest()`), exercise all 8 hardcoded excluded names plus a positive "kept" control, and assert non-trivially (exact target list / digest equality and inequality) - not vacuous checks.

  Root cause the tests cannot go Red: U-001 is a behavior-preserving consolidation refactor (extract one `pub(crate) EXCLUDED_DIRS` in project.rs, have snapshot.rs `use` it instead of keeping its own copy). Today both files already independently define the identical, correct 8-entry array, so `package_targets()` and `compute_digest()` already produce the exact behavior T-001/T-002 assert. The contract also requires the test fixtures to be literals in the test body rather than references to the EXCLUDED_DIRS constant (so a future accidental deletion from the array is caught) - this is deliberate and correct, but it also means these tests observe only externally-visible discovery/digest behavior, which a pure consolidation does not change. There is no behavior delta for a behavioral test to catch before vs. after this refactor; Red is unreachable in principle here, not merely unobserved due to a weak test.

  Considered and rejected a structural alternative (a compile-time/pointer-equality test asserting snapshot.rs's array is the same object as project.rs's, which would currently fail since neither is `pub(crate)` yet): rejected because it contradicts the "fixture must not reference EXCLUDED_DIRS" contract, a private-const reference would be a compile error (cargo test would run zero tests, not a clean Red), pointer equality of `&[&str]` consts is not a reliable language guarantee, and it is a new scenario outside the T-001/T-002 plan.

  Per the task instruction ("If the tests do not fail, do not implement; write the reason in notes"), no production code was changed. The two tests remain in place as durable regression guards for the eventual EXCLUDED_DIRS consolidation's Green step.

### (7) code 段階の独立検証結果

tests=true, gates=true

---

## How to Test

```
cargo test project::tests::discovery_skips_all_hardcoded_excluded_names_but_keeps_control_pkg
cargo test snapshot::tests::digest_ignores_all_hardcoded_excluded_dirs_but_tracks_control_file
cargo test
```

Claude-Session: https://claude.ai/code/session_01BeaGUYTQkNNytMaaKZ6tnc
