### PR TITLE
fix: EXCLUDED_DIRS DRY 統一 (#117) と jscpd.ignore merge 化 (#118)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -277,12 +277,7 @@ fn run_with_overrides(project_dir: &Path, overrides: &tools::EnvOverrides) -> Op
             .threshold
             .unwrap_or(tools::DEFAULT_JSCPD_THRESHOLD);
         let block = config.jscpd.block.unwrap_or(false);
-        let ignore = config.jscpd.ignore.clone().unwrap_or_else(|| {
-            tools::DEFAULT_JSCPD_IGNORE
-                .iter()
-                .map(|s| (*s).to_owned())
-                .collect()
-        });
+        let ignore = tools::merge_jscpd_ignore(config.jscpd.ignore.as_deref());
         tasks.push((
             vec!["jscpd"],
             thread::spawn(move || {

--- a/src/project.rs
+++ b/src/project.rs
@@ -2,13 +2,16 @@ use crate::traverse;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-/// Directory names package discovery never descends into: dependencies, VCS,
+/// Directory names a downward walk never descends into: dependencies, VCS,
 /// build output, coverage/next caches, and Claude Code tooling cannot own a
-/// first-party package target. Extends the list `depgraph`/`snapshot` apply to
-/// their own downward walks with the cache dirs that commonly hold copied
+/// first-party package target. Covers the cache dirs that commonly hold copied
 /// `package.json` fixtures and `.claude`, whose `plugins/<plugin>` members carry
 /// their own manifests but are third-party tooling, not code to gate.
-const EXCLUDED_DIRS: &[&str] = &[
+///
+/// Single source of truth for the identical exclusion `snapshot` applies to its
+/// own downward walk; `depgraph`'s list is narrower because it only walks `src/`
+/// downward and never reaches these siblings.
+pub const EXCLUDED_DIRS: &[&str] = &[
     "node_modules",
     ".git",
     "dist",
@@ -124,6 +127,15 @@ mod tests {
     use crate::test_utils::{GUARDED_EXCLUDED_DIR_NAMES, TempDir};
     use crate::tools::run_graph_gates;
     use std::fs;
+
+    // Pins the shared production constant to the fixture the behavioral guard
+    // tests (here and in `snapshot`) iterate. Without this, adding a name to
+    // `EXCLUDED_DIRS` without also adding it to `GUARDED_EXCLUDED_DIR_NAMES`
+    // would leave the new exclusion unguarded, and vice versa.
+    #[test]
+    fn excluded_dirs_matches_guarded_fixture() {
+        assert_eq!(EXCLUDED_DIRS, GUARDED_EXCLUDED_DIR_NAMES);
+    }
 
     #[test]
     fn detects_both_files() {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -18,22 +18,11 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-/// Directories whose contents never belong to the gated fileset: dependencies,
-/// VCS, build/test artifacts (`dist`/`build`/`target`/`coverage`/`.next`), and
-/// `.claude` (Claude Code tooling, whose `plugins/<plugin>` sources are
-/// third-party and are also excluded from package discovery at `project.rs`).
-/// Kept in sync with `project.rs::EXCLUDED_DIRS`; `depgraph`'s list is narrower
-/// because it only walks `src/` downward and never reaches these siblings.
-const EXCLUDED_DIRS: &[&str] = &[
-    "node_modules",
-    ".git",
-    "dist",
-    "build",
-    "target",
-    "coverage",
-    ".next",
-    ".claude",
-];
+// Directories whose contents never belong to the gated fileset. Shares the
+// single definition at `project.rs::EXCLUDED_DIRS` so package discovery and the
+// snapshot walk cannot drift; `depgraph`'s list is narrower because it only
+// walks `src/` downward and never reaches these siblings.
+use crate::project::EXCLUDED_DIRS;
 
 /// Source extensions gates consumes (tsc/eslint/embedded gates).
 const SOURCE_EXTS: &[&str] = &["ts", "tsx", "cts", "mts", "js", "jsx", "cjs", "mjs"];

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -692,6 +692,27 @@ pub const DEFAULT_JSCPD_IGNORE: &[&str] = &[
     "**/dist/**",
 ];
 
+/// Merges user-configured `jscpd.ignore` globs onto the structural defaults
+/// (#118). The defaults (`.claude/**`, `.git/**`, …) are never-scan targets, so
+/// a user list extends them rather than replacing them; replacing silently
+/// dropped these exclusions. Dedup keeps a user echo of a default from doubling
+/// the glob. Defaults stay first so their ordering is stable regardless of the
+/// user list.
+pub fn merge_jscpd_ignore(user: Option<&[String]>) -> Vec<String> {
+    let mut ignore: Vec<String> = DEFAULT_JSCPD_IGNORE
+        .iter()
+        .map(|s| (*s).to_owned())
+        .collect();
+    if let Some(user) = user {
+        for glob in user {
+            if !ignore.contains(glob) {
+                ignore.push(glob.clone());
+            }
+        }
+    }
+    ignore
+}
+
 const JSCPD_HINT: &str = "Extract the duplicated code into a shared function or module (DRY).";
 
 /// Subset of jscpd's JSON report the gate reads. `duplicates` and its inner
@@ -979,6 +1000,36 @@ mod tests {
         assert!(
             DEFAULT_JSCPD_IGNORE.contains(&"**/.claude/**"),
             "DEFAULT_JSCPD_IGNORE must exclude .claude by default"
+        );
+    }
+
+    #[test]
+    fn merge_jscpd_ignore_without_user_config_returns_defaults() {
+        assert_eq!(merge_jscpd_ignore(None), DEFAULT_JSCPD_IGNORE.to_vec());
+    }
+
+    #[test]
+    fn merge_jscpd_ignore_extends_defaults_rather_than_replacing() {
+        let user = vec!["**/vendor/**".to_owned()];
+        let merged = merge_jscpd_ignore(Some(&user));
+        // Every structural default survives a user-supplied ignore (#118).
+        for &def in DEFAULT_JSCPD_IGNORE {
+            assert!(
+                merged.contains(&def.to_owned()),
+                "default {def} was dropped"
+            );
+        }
+        assert!(merged.contains(&"**/vendor/**".to_owned()));
+    }
+
+    #[test]
+    fn merge_jscpd_ignore_dedups_user_echo_of_a_default() {
+        let user = vec!["**/.claude/**".to_owned(), "**/vendor/**".to_owned()];
+        let merged = merge_jscpd_ignore(Some(&user));
+        let claude_count = merged.iter().filter(|g| *g == "**/.claude/**").count();
+        assert_eq!(
+            claude_count, 1,
+            "a user echo of a default must not duplicate"
         );
     }
 


### PR DESCRIPTION
audit (`/audit` on commit 8441ec4) 由来の RC-1 (#117) / RC-2 (#118) を検証し、両者とも現行コードで問題が実在することを確認した上で修正する。

## #117: EXCLUDED_DIRS の DRY 統一 (RC-1)

`project.rs` と `snapshot.rs` でバイト同一だった `EXCLUDED_DIRS` を `project.rs::EXCLUDED_DIRS` (`pub`) に一本化。`snapshot.rs` は import で共有し、コメント同期依存 (`Kept in sync with ...`) を排除。片側だけ更新するドリフトを構造的に防ぐ。

- production const == `GUARDED_EXCLUDED_DIR_NAMES` (guard fixture) を検証するテストを追加し、production と behavioral guard 間の追加漏れも static に検出。
- `depgraph.rs` は `src/` 配下のみ下向き走査し `.claude` 兄弟に到達しないため意図的に narrower のまま (統一対象外)。

## #118: jscpd.ignore の merge 化 (RC-2)

`main.rs` はユーザ `jscpd.ignore` 設定時に `DEFAULT_JSCPD_IGNORE` を**置換**しており、`.claude/**` や `.git/**` 等の構造的デフォルト除外が黙って外れていた。

- `tools::merge_jscpd_ignore` に抽出し、デフォルト (never-scan 対象) を常に有効化した上でユーザ値を dedup 追加する merge 方式に変更。
- **設計判断 (a): 常に merge。** 7 つのデフォルトは全て hook 速度前提の never-scan 対象で、デフォルトの opt-out は実需要が未観測。空配列 opt-out は「空=除外なし/デフォルト」の曖昧さを生む footgun のため採らない。
- None / extend / dedup の 3 ケースをカバーするテストを追加。

## 検証

- `cargo test`: 280 passed
- `cargo clippy --all-targets`: warning なし

Closes #117
Closes #118

https://claude.ai/code/session_01RgffeWMoR7dAWyVhA9Jko7