### PR TITLE
test: EXCLUDED_DIRS 削除ドリフトを検知するガードテストを追加 (#128)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,9 +175,9 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -531,9 +531,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"

--- a/src/depgraph.rs
+++ b/src/depgraph.rs
@@ -286,6 +286,42 @@ mod tests {
         assert_eq!(graph.files.len(), 1);
     }
 
+    // T-109: the remaining 4 hardcoded EXCLUDED_DIRS entries (.git/dist/build/
+    // target) are still excluded from collection, while a sibling control file
+    // is still collected. Removing an entry from EXCLUDED_DIRS makes this fail.
+    #[test]
+    fn excludes_remaining_hardcoded_dirs_but_collects_control_file() {
+        // Intentional duplicate of EXCLUDED_DIRS: kept local so that deleting an
+        // entry from the production list breaks this test instead of silently
+        // shrinking the loop.
+        let excluded_dirs = [".git", "dist", "build", "target"];
+
+        let tmp = TempDir::new("depgraph-excluded-dirs");
+        let src = tmp.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("kept.ts"), "export const kept = 1;\n").unwrap();
+
+        for dir in excluded_dirs {
+            let sub = src.join(dir);
+            fs::create_dir_all(&sub).unwrap();
+            fs::write(sub.join("excluded.ts"), "export const excluded = 1;\n").unwrap();
+        }
+
+        let graph = build(&src);
+        let names: HashSet<&str> = graph
+            .files
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
+            .collect();
+        let expected: HashSet<&str> = HashSet::from(["kept.ts"]);
+        assert_eq!(
+            names, expected,
+            "excluded dirs must not contribute files, got {:?}",
+            names
+        );
+        assert!(graph.files.contains(&canon(&src.join("kept.ts"))));
+    }
+
     // T-107: an empty directory yields empty graph data.
     #[test]
     fn empty_directory() {


### PR DESCRIPTION
## Summary

- Adds a drift-guard test (`excludes_remaining_hardcoded_dirs_but_collects_control_file`, T-109) so removing any of the 4 remaining hardcoded entries in `src/depgraph.rs:9` `EXCLUDED_DIRS` (`.git`, `dist`, `build`, `target`) makes `cargo test` fail, alongside a sibling control file that must still be collected.
- Approach: build a fixture tree with one excluded subdirectory per entry plus a control file, run `build()`, and assert the excluded files are absent while the control file is present.
- Test-only change; no production code touched. `Cargo.lock` also shows two incidental dependency bumps (num-bigint, rustc-hash) unrelated to this change.
- Review focus: whether the local `excluded_dirs` duplicate in the test is an acceptable trade-off (it intentionally mirrors `EXCLUDED_DIRS` so a deletion in production breaks the test, rather than importing the constant and risking a vacuous pass).


---

Closes #128

`verify tests=pass gates=pass` · `blocking 0`

**Backlog — file via `/issue`**
- [issue] EXCLUDED_DIRS へのエントリ追加時のドリフト保護。本issueは削除ドリフトに限定。定数の共有化は#117の共通化と併せて検討

**Spec conformance (separate axis, review independently)**
- [scope_creep] The declared scope is a test-only addition to src/depgraph.rs. The working-tree diff also bumps two locked dependency versions in Cargo.lock, which the issue does not ask for. Likely incidental lockfile drift, but it is outside the stated scope of "src/depgraph.rs へのテスト追加のみ". Severity: low. (Cargo.lock (num-bigint 0.4.6→0.4.8, rustc-hash 2.1.2→2.1.3), 対象 | `src/depgraph.rs` へのテスト追加のみ。プロダクションコードの変更なし)

**Anomalies (Red unconfirmed)**
- U-001 (no-red): This is a drift-guard test, not a bug-reproduction test. EXCLUDED_DIRS (src/depgraph.rs:9) already contains all 4 target entries (.git/dist/build/target) alongside node_modules, so the behavior under test is already implemented and the test correctly passes green: `cargo test excludes_remaining_hardcoded_dirs_but_collects_control_file` -> 1 passed. Scrutiny performed: assertions are non-empty (HashSet equality with {:?} diagnostic, plus a canon()-based membership check on kept.ts), and build() is genuinely invoked on a real TempDir tree with 4 excluded-dir fixtures + 1 control file. To confirm the test isn't vacuously passing, EXCLUDED_DIRS was temporarily mutated (removed ".git") and the test failed as expected with `got {"kept.ts", "excluded.ts"}`, then the file was restored. git diff --stat confirms only the new T-109 test was added to src/depgraph.rs; no production code or existing tests (T-106, T-107) were touched. This matches the established pattern for guard tests in this repo (e.g. commit 66ca8d0).
