### PR TITLE
test: depgraph.rs EXCLUDED_DIRS の add-drift をpinテストで検知する

### DIFF
--- a/src/depgraph.rs
+++ b/src/depgraph.rs
@@ -166,6 +166,16 @@ mod tests {
         path.canonicalize().unwrap()
     }
 
+    // Pin EXCLUDED_DIRS's exact contents/order so an accidental addition,
+    // removal, or reordering is caught immediately by this single test.
+    #[test]
+    fn excluded_dirs_is_pinned() {
+        assert_eq!(
+            EXCLUDED_DIRS,
+            &["node_modules", ".git", "dist", "build", "target"]
+        );
+    }
+
     // T-101: relative import a -> b records an intra-project edge, no external.
     #[test]
     fn relative_import_records_edge() {


### PR DESCRIPTION
## What & Why

`src/depgraph.rs` の `EXCLUDED_DIRS` にエントリを追加・削除・並べ替えしても、これまで壊れずに通ってしまう状態だった。project.rs / snapshot.rs にはすでに同種の drift-guard テストがあるが、depgraph.rs だけ抜けていた。本 PR で depgraph にも同じ保護を追加し、3 ファイルで一貫したガードを持たせる。

## Changes

- `excluded_dirs_is_pinned` テストを追加し、`EXCLUDED_DIRS` の内容 `[node_modules, .git, dist, build, target]` と順序をインラインの `assert_eq!` で pin した。

## Design Decisions

- インラインリテラル1本の `assert_eq!(EXCLUDED_DIRS, &[node_modules, .git, dist, build, target])` を追加する。リテラルは名前付き定数ではないためリファクタが不用意に同期しない。追加/削除/並べ替えドリフトを1本で全pinし、T-109 の削除保証も包摂する。
- 名前付き guarded 定数は新設しない。同一ファイル内に2本目のリストを置くと、隣接する両者を一緒に編集した際に assert が通り独立性が無い。project.rs の `GUARDED` は test_utils 共有で2ファイルから iterate されるため価値があるが、depgraph では消費者が1テストのみで循環的になる(内部 critic 指摘)。
- T-109 はリファクタしない。T-109 のハードコード複製は削除ドリフトの独立コピーとして機能する(#128)。共有定数駆動に変えると独立性が失われるため、無変更で温存する。
- 共有 `test_utils::GUARDED_EXCLUDED_DIR_NAMES` は再利用しない。`coverage`/`.next`/`.claude` を含む8エントリで depgraph の5エントリと不一致になり、assert が誤って失敗する(#128で確認済み)。

## How to Test

1. `cargo test excluded_dirs_is_pinned` を実行する。
2. `EXCLUDED_DIRS` の要素を1つ削除・追加・並べ替えて再実行し、失敗することを確認する(手元検証済み、diff には含めない)。


---

Closes #132

`verify tests=pass gates=pass` · `blocking 0`

**Backlog (`/issue` で起票)**
- [audit] Confirmed by the challenge pass and corroborated by the verification pass (both low). Two inline drift-guard literals live in the same file: line 175 pins EXCLUDED_DIRS with all 5 entries [node_modules,.git,dist,build,target], while line 307 (test T-109) declares a deliberately narrower 4-entry subset [.git,dist,build,target] under the 'Intentional duplicate: kept local' comment, omitting node_modules because it has its own behavioral guard (T-106). Both serve the same drift-guard purpose with independent hand-maintained literals. This is the only correctly-scoped survivor: the three sibling findings (depgraph.rs:172-176, 169-177, 168-177) were pruned as false positives by the challenge pass and stay pruned under the membership rule even though the verification pass found evidence for them, because they rest on a false equivalence — depgraph's private 5-entry EXCLUDED_DIRS is a distinct constant that cannot reuse the shared 8-entry GUARDED_EXCLUDED_DIR_NAMES fixture (which adds coverage/.next/.claude and is pinned by 2 consumers, project.rs and snapshot.rs), so the recommended shared-fixture extraction would open an abstraction gate for a single consumer. Severity is low and stable across both passes: test-only, zero runtime impact. Root cause (5 Whys) is a Knowledge Gap of minor deliberate in-file duplication; acting on it is marginal because the two literals are intentionally different (the subset omits node_modules), so a single shared local constant would trade one small duplication for coupling a behavioral fixture to a full-contract pin. Not auto-fixable — the merge requires human judgment on that coupling tradeoff, with no unambiguous single-line fix pattern. (src/depgraph.rs, low)

**異常 (Red 未確認)**
- U-001 (no-red): U-001 (excluded_dirs_is_pinned) is a pin/drift-guard test, not a Red-step behavior test. Contract and scenario T-110 both explicitly state "現状は pass する" — the behavior (EXCLUDED_DIRS containing exactly [node_modules, .git, dist, build, target]) is already implemented in production code (src/depgraph.rs:9), so this test is designed to be green immediately, guarding against future drift rather than driving new implementation. Verified: test added verbatim per contract (inline literal assert_eq!, plain // rationale comment, no T-number, placed right after canon() and before T-101, no new imports/constants, matching project.rs:137 convention). cargo test excluded_dirs_is_pinned passes (1 passed). Drift-guard efficacy was independently confirmed in the prior session (temporarily removing "target" caused failure; restoring made it pass again). git diff shows only +10 lines added to src/depgraph.rs, no production code changes.
